### PR TITLE
Add support for forcus reporting mode (xterm)

### DIFF
--- a/TerminalEmulator/TerminalBase.cs
+++ b/TerminalEmulator/TerminalBase.cs
@@ -343,6 +343,10 @@ namespace Poderosa.Terminal {
             return false;
         }
 
+        public virtual bool GetFocusReportingMode() {
+            return false;
+        }
+
         #region IByteAsyncInputStream
         public void OnReception(ByteDataFragment data) {
             try {

--- a/TerminalEmulator/TerminalControl.cs
+++ b/TerminalEmulator/TerminalControl.cs
@@ -774,6 +774,10 @@ namespace Poderosa.Terminal {
             base.OnGotFocus(args);
             if (!this.EnabledEx)
                 return;
+            if (GetTerminal().GetFocusReportingMode()) {
+                byte[] data = new byte[] { 0x1b, 0x5b, 0x49 };
+                TransmitDirect(data, 0, data.Length);
+            }
 
             if (this.CharacterDocument != null) { //‰Šú‰»‰ß’ö‚Ì‚Æ‚«‚Í–³‹
 
@@ -787,6 +791,10 @@ namespace Poderosa.Terminal {
             base.OnLostFocus(args);
             if (!this.EnabledEx)
                 return;
+            if (GetTerminal().GetFocusReportingMode()) {
+                byte[] data = new byte[] { 0x1b, 0x5b, 0x4f };
+                TransmitDirect(data, 0, data.Length);
+            }
 
             if (_inIMEComposition)
                 ClearIMEComposition();

--- a/TerminalEmulator/XTerm.cs
+++ b/TerminalEmulator/XTerm.cs
@@ -51,6 +51,7 @@ namespace Poderosa.Terminal {
 
         private MouseTrackingState _mouseTrackingState = MouseTrackingState.Off;
         private MouseTrackingProtocol _mouseTrackingProtocol = MouseTrackingProtocol.Normal;
+        private bool _focusReportingMode = false;
         private int _prevMouseRow = -1;
         private int _prevMouseCol = -1;
         private MouseButtons _mouseButton = MouseButtons.None;
@@ -66,6 +67,10 @@ namespace Poderosa.Terminal {
             _isAlternateBuffer = false;
             _savedMode_isAlternateBuffer = false;
             InitTabStops();
+        }
+
+        public override bool GetFocusReportingMode() {
+            return _focusReportingMode;
         }
 
         public override void ProcessChar(char ch) {
@@ -639,8 +644,7 @@ namespace Poderosa.Terminal {
                     ResetMouseTracking((set) ? MouseTrackingState.Any : MouseTrackingState.Off);
                     return ProcessCharResult.Processed;
                 case "1004": // Send FocusIn/FocusOut events
-                    // Not supported
-                    ResetMouseTracking(MouseTrackingState.Off);
+                    _focusReportingMode = set;
                     return ProcessCharResult.Processed;
                 case "1005": // Enable UTF8 Mouse Mode
                     if (set) {


### PR DESCRIPTION
This patch adds "focus repoting mode" feature (xterm, private mode 1004) to Poderosa. this provides focus-aware usability to some terminal applications. When this mode is enabled, CSI I (focus-in event) and CSI O (focus-out event) will be fired.
