### PR TITLE
change url of Poderosa web site.

### DIFF
--- a/Core/BasicCommands.cs
+++ b/Core/BasicCommands.cs
@@ -414,7 +414,7 @@ namespace Poderosa.Commands {
         }
         private static CommandResult CmdOpenWeb(ICommandTarget target) {
             try {
-                Process p = Process.Start("http://www.poderosa.org/");
+                Process p = Process.Start("http://poderosa.sourceforge.net/");
                 return p == null ? CommandResult.Failed : CommandResult.Succeeded;
             }
             catch (Exception) {


### PR DESCRIPTION
[ヘルプ]-[PoderosaのWebを開く]で開くURLの変更です。
poderosa.orgドメインは失効して第三者に取得され、現状では正体不明なダウンロードリンクの広告が表示されるので、変えた方がいいと思います。