### PR TITLE
Increase DH random number(key) size.

### DIFF
--- a/Granados/SSH2Connection.cs
+++ b/Granados/SSH2Connection.cs
@@ -1313,7 +1313,7 @@ namespace Granados.SSH2 {
 
         private DataFragment SendKEXDHINIT(Mode mode) {
             //Round1 computes and sends [e]
-            byte[] sx = new byte[16];
+            byte[] sx = new byte[32];
             _param.Random.NextBytes(sx);
             _x = new BigInteger(sx);
             _e = new BigInteger(2).modPow(_x, GetDiffieHellmanPrime(_cInfo._kexAlgorithm));


### PR DESCRIPTION
DHで使用する乱数(秘密鍵)のサイズを、対応している共有鍵暗号方式で最大の鍵サイズを持つAES256-CTRに合わせて256bitに増やします。
OpenSSLでは共通鍵暗号の鍵サイズやHMACの鍵サイズ等で最大のものに合わせたサイズを使用していますが、簡単のため256ビット固定にしています。
AES128に対してはオーバースペックとなりますが、DH鍵交換は通信開始時および鍵の再交換時のみに行われるので、パフォーマンスへの影響はほぼないと思います。