### PR TITLE
use System.Security.Cryptography.RNGCryptoServiceProvider instead of …

### DIFF
--- a/Granados/ConnectionParameter.cs
+++ b/Granados/ConnectionParameter.cs
@@ -8,6 +8,7 @@
 */
 
 using System;
+using System.Security.Cryptography;
 
 using Granados.PKI;
 
@@ -150,13 +151,13 @@ namespace Granados {
             }
         }
 
-        private Random _random;
-        public Random Random {
+        private RNGCryptoServiceProvider _rng;
+        public RNGCryptoServiceProvider Rng {
             get {
-                return _random;
+                return _rng;
             }
             set {
-                _random = value;
+                _rng = value;
             }
         }
 
@@ -226,7 +227,7 @@ namespace Granados {
         }
 
         public SSHConnectionParameter() {
-            _random = new Random();
+            _rng = new RNGCryptoServiceProvider();
             _authtype = AuthenticationType.Password;
             _terminalname = "vt100";
             _width = 80;
@@ -251,7 +252,7 @@ namespace Granados {
             n._maxpacketsize = _maxpacketsize;
             n._password = _password;
             n._protocol = _protocol;
-            n._random = _random;
+            n._rng = _rng;
             n._terminalname = _terminalname;
             n._username = _username;
             n._width = _width;

--- a/Granados/Poderosa/SFTP/SFTPPacket.cs
+++ b/Granados/Poderosa/SFTP/SFTPPacket.cs
@@ -56,16 +56,16 @@ namespace Granados.Poderosa.SFTP {
         /// Overrides Close()
         /// </summary>
         /// <param name="cipher"></param>
-        /// <param name="rnd"></param>
+        /// <param name="rng"></param>
         /// <param name="mac"></param>
         /// <param name="sequence"></param>
         /// <returns></returns>
-        public override DataFragment Close(Cipher cipher, Random rnd, MAC mac, int sequence) {
+        public override DataFragment Close(Cipher cipher, System.Security.Cryptography.RNGCryptoServiceProvider rng, MAC mac, int sequence) {
             byte[] buf = DataWriter.UnderlyingBuffer;
             int sftpDataLength = DataWriter.Length - OFFSET_SFTP_PACKET_TYPE;
             SSHUtil.WriteIntToByteArray(buf, OFFSET_CHANNEL_DATA_LENGTH, sftpDataLength + 4);
             SSHUtil.WriteIntToByteArray(buf, OFFSET_SFTP_DATA_LENGTH, sftpDataLength);
-            return base.Close(cipher, rnd, mac, sequence);
+            return base.Close(cipher, rng, mac, sequence);
         }
     }
 }

--- a/Granados/RSA.cs
+++ b/Granados/RSA.cs
@@ -258,16 +258,16 @@ namespace Granados.PKI {
     /// <exclude/>
     public class RSAUtil {
 
-        public static BigInteger PKCS1PadType2(BigInteger input, int pad_len, Random rand) {
+        public static BigInteger PKCS1PadType2(BigInteger input, int pad_len, RNGCryptoServiceProvider rng) {
             int input_byte_length = (input.bitCount() + 7) / 8;
             //System.out.println(String.valueOf(pad_len) + ":" + input_byte_length);
             byte[] pad = new byte[pad_len - input_byte_length - 3];
 
             for (int i = 0; i < pad.Length; i++) {
                 byte[] b = new byte[1];
-                rand.NextBytes(b);
+                rng.GetBytes(b);
                 while (b[0] == 0)
-                    rand.NextBytes(b); //0‚Å‚Í‚¾‚ß‚¾
+                    rng.GetBytes(b); //0‚Å‚Í‚¾‚ß‚¾
                 pad[i] = b[0];
             }
 

--- a/Granados/SSH1Connection.cs
+++ b/Granados/SSH1Connection.cs
@@ -175,7 +175,7 @@ namespace Granados.SSH1 {
         private byte[] GenerateSessionKey() {
             //session key(256bits)
             byte[] session_key = new byte[32];
-            _param.Random.NextBytes(session_key);
+            _param.Rng.GetBytes(session_key);
 
             return session_key;
         }
@@ -207,8 +207,8 @@ namespace Granados.SSH1 {
                     second_key_bytelen = (si.server_key_bits + 7) / 8;
                 }
 
-                BigInteger first_result = RSAUtil.PKCS1PadType2(new BigInteger(working_data), first_key_bytelen, _param.Random).modPow(first_encryption.Exponent, first_encryption.Modulus);
-                BigInteger second_result = RSAUtil.PKCS1PadType2(first_result, second_key_bytelen, _param.Random).modPow(second_encryption.Exponent, second_encryption.Modulus);
+                BigInteger first_result = RSAUtil.PKCS1PadType2(new BigInteger(working_data), first_key_bytelen, _param.Rng).modPow(first_encryption.Exponent, first_encryption.Modulus);
+                BigInteger second_result = RSAUtil.PKCS1PadType2(first_result, second_key_bytelen, _param.Rng).modPow(second_encryption.Exponent, second_encryption.Modulus);
 
                 //output
                 SSH1DataWriter writer = new SSH1DataWriter();

--- a/Granados/SSH2Connection.cs
+++ b/Granados/SSH2Connection.cs
@@ -398,7 +398,7 @@ namespace Granados.SSH2 {
 
         internal void TransmitPacket(SSH2TransmissionPacket packet) {
             lock (_transmitSync) {
-                DataFragment data = packet.Close(_tCipher, _param.Random, _tMAC, _tSequence++);
+                DataFragment data = packet.Close(_tCipher, _param.Rng, _tMAC, _tSequence++);
                 _stream.Write(data.Data, data.Offset, data.Length);
             }
         }
@@ -411,7 +411,7 @@ namespace Granados.SSH2 {
 
         internal DataFragment SynchronizedTransmitPacket(SSH2TransmissionPacket packet) {
             lock (_transmitSync) {
-                DataFragment data = packet.Close(_tCipher, _param.Random, _tMAC, _tSequence++);
+                DataFragment data = packet.Close(_tCipher, _param.Rng, _tMAC, _tSequence++);
                 return _packetReceiver.SendAndWaitResponse(data);
             }
         }
@@ -1199,7 +1199,7 @@ namespace Granados.SSH2 {
             SSH2DataWriter wr = new SSH2DataWriter();
             wr.WritePacketType(PacketType.SSH_MSG_KEXINIT);
             byte[] cookie = new byte[16];
-            _param.Random.NextBytes(cookie);
+            _param.Rng.GetBytes(cookie);
             wr.Write(cookie);
             wr.WriteString(GetSupportedKexAlgorithms()); //    kex_algorithms
             wr.WriteString(FormatHostKeyAlgorithmDescription());            //    server_host_key_algorithms
@@ -1314,7 +1314,7 @@ namespace Granados.SSH2 {
         private DataFragment SendKEXDHINIT(Mode mode) {
             //Round1 computes and sends [e]
             byte[] sx = new byte[16];
-            _param.Random.NextBytes(sx);
+            _param.Rng.GetBytes(sx);
             _x = new BigInteger(sx);
             _e = new BigInteger(2).modPow(_x, GetDiffieHellmanPrime(_cInfo._kexAlgorithm));
             SSH2DataWriter wr = new SSH2DataWriter();

--- a/Granados/SSH2Packet.cs
+++ b/Granados/SSH2Packet.cs
@@ -16,7 +16,7 @@ using System.Collections;
 using System.IO;
 using System.Threading;
 using System.Diagnostics;
-using HMACSHA1 = System.Security.Cryptography.HMACSHA1;
+using System.Security.Cryptography;
 
 using Granados.Crypto;
 using Granados.IO;
@@ -70,7 +70,7 @@ namespace Granados.SSH2 {
         }
 
         // Derived class can override this method to modify the buffer.
-        public virtual DataFragment Close(Cipher cipher, Random rnd, MAC mac, int sequence) {
+        public virtual DataFragment Close(Cipher cipher, RNGCryptoServiceProvider rng, MAC mac, int sequence) {
             if (!_isOpen)
                 throw new SSHException("internal state error");
 
@@ -83,8 +83,11 @@ namespace Granados.SSH2 {
             int imageLength = packetLength + LENGTH_MARGIN;
 
             //fill padding
-            for (int i = 0; i < paddingLength; i += 4)
-                _writer.WriteInt32(rnd.Next());
+	    byte[] tmp = new byte[4];
+            for (int i = 0; i < paddingLength; i += 4) {
+		rng.GetBytes(tmp);
+                _writer.Write(tmp);
+	    }
 
             //manipulate stream
             byte[] rawbuf = _writer.UnderlyingBuffer;


### PR DESCRIPTION
通信に使用する乱数生成器としてSystem.Randomは相応しくないため、暗号用の乱数生成器であるSystem.Security.Cryptography.RNGCryptoServiceProvider への置き換えです。
少なくともDHの鍵生成への変更は必須だと思います。
padding部分にも適用すべきかは自分にはわかりませんでしたが、念のためこちらも置き換えています。
計測していませんが、padding部分の置き換えは通信パフォーマンスに影響するかもしれません。

SSH認証鍵作成部分には手をいれていませんが、こちらも置き換えた方がいいかもしれません。
