### PR TITLE
Please merge (Add connection profile plugin)

### DIFF
--- a/ConnectProfile/Commands.cs
+++ b/ConnectProfile/Commands.cs
@@ -1,0 +1,747 @@
+﻿using System;
+using System.Drawing;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Windows.Forms;
+
+using Granados;
+using Poderosa.Commands;
+using Poderosa.ConnectionParam;
+using Poderosa.Protocols;
+using Poderosa.Sessions;
+using Poderosa.Terminal;
+using Poderosa.View;
+
+
+namespace Poderosa.ConnectProfile {
+    /// <summary>
+    /// プロファイルリスト操作クラス
+    /// </summary>
+    internal class Commands {
+        // メンバー変数
+        private static bool _connectCancelFlg;
+
+        /// <summary>
+        /// プロファイルを新規作成
+        /// </summary>
+        /// <param name="proflist">プロファイルリスト</param>
+        public void NewProfileCommand(ConnectProfileList proflist) {
+            ProfileEditForm dlg = new ProfileEditForm(null);
+            if (dlg.ShowDialog() == DialogResult.OK) {
+                AddProfileCommand(proflist, dlg.ResultProfile);
+            }
+        }
+
+        /// <summary>
+        /// プロファイルを追加
+        /// </summary>
+        /// <param name="proflist">プロファイルリスト</param>
+        /// <param name="prof">プロファイル</param>
+        public void AddProfileCommand(ConnectProfileList proflist, ConnectProfileStruct prof) {
+            proflist.AddProfile(prof);
+        }
+
+        /// <summary>
+        /// プロファイルを編集
+        /// </summary>
+        /// <param name="proflist">プロファイルリスト</param>
+        /// <param name="prof">プロファイル</param>
+        public void EditProfileCommand(ConnectProfileList proflist, ConnectProfileStruct prof) {
+            ProfileEditForm dlg = new ProfileEditForm(prof);
+            if (dlg.ShowDialog() == DialogResult.OK) {
+                proflist.ReplaceProfile(prof, dlg.ResultProfile);
+            }
+        }
+
+        /// <summary>
+        /// プロファイルをコピーして編集
+        /// </summary>
+        /// <param name="proflist">プロファイルリスト</param>
+        /// <param name="prof">コピー元プロファイル</param>
+        public void CopyEditProfileCommand(ConnectProfileList proflist, ConnectProfileStruct prof) {
+            ProfileEditForm dlg = new ProfileEditForm(prof);
+            if (dlg.ShowDialog() == DialogResult.OK) {
+                proflist.AddProfile(dlg.ResultProfile);
+            }
+        }
+
+        /// <summary>
+        /// プロファイルを削除
+        /// </summary>
+        /// <param name="proflist">プロファイルリスト</param>
+        /// <param name="prof">プロファイル</param>
+        public void DeleteProfileCommand(ConnectProfileList proflist, ConnectProfileStruct prof) {
+            proflist.DeleteProfile(prof);
+        }
+
+        /// <summary>
+        /// 全プロファイルリストを置換
+        /// </summary>
+        /// <param name="proflist1">置換前プロファイルリスト</param>
+        /// <param name="proflist2">置換後プロファイルリスト</param>
+        public void ReplaceAllProfileCommand(ConnectProfileList proflist1, ConnectProfileList proflist2) {
+            proflist1.ReplaceAllProfile(proflist2);
+        }
+
+        /// <summary>
+        /// 接続
+        /// </summary>
+        /// <param name="prof">プロファイル</param>
+        public void ConnectProfile(ConnectProfileStruct prof) {
+            _connectCancelFlg = false;
+
+            ConnectProfileTerminal terminal = new ConnectProfileTerminal(prof);
+            Thread _connectThread = new Thread((ThreadStart)delegate() {
+                terminal.Connect();
+            });
+            _connectThread.IsBackground = true;
+            _connectThread.Start();
+
+            // スレッド終了待機(Joinを使用するとフリーズしてしまう)
+            while (true) {
+                Thread.Sleep(10);
+                if (_connectCancelFlg == true) _connectThread.Abort(); // 接続キャンセル(スレッド終了)
+                if (_connectThread.IsAlive != true) break; // スレッド終了後break
+                System.Windows.Forms.Application.DoEvents();
+            }
+        }
+
+        /// <summary>
+        /// 接続キャンセル
+        /// </summary>
+        public void ConnectCancel() {
+            _connectCancelFlg = true;
+        }
+
+        /// <summary>
+        /// CSV変換
+        /// </summary>
+        /// <param name="prof">プロファイル</param>
+        /// <param name="hidepw">パスワードを隠す</param>
+        public string ConvertCSV(ConnectProfileStruct prof, bool hidepw) {
+            return string.Format(
+                ConnectProfileStruct.FMT_CSV,
+                prof.HostName,
+                prof.Protocol.ToString(),
+                prof.Port.ToString(),
+                prof.AuthType.ToString(),
+                prof.KeyFile,
+                prof.UserName,
+                (hidepw == true) ? "" : prof.Password,
+                prof.AutoLogin.ToString(),
+                prof.LoginPrompt,
+                prof.PasswordPrompt,
+                prof.ExecCommand,
+                prof.SUUserName,
+                (hidepw == true) ? "" : prof.SUPassword,
+                prof.SUType,
+                prof.CharCode.ToString(),
+                prof.NewLine.ToString(),
+                prof.TelnetNewLine.ToString(),
+                prof.TerminalType.ToString(),
+                Convert.ToString(prof.TerminalFontColor.ToArgb(), 16),
+                Convert.ToString(prof.TerminalBGColor.ToArgb(), 16),
+                prof.CommandSendInterval.ToString(),
+                prof.PromptRecvTimeout.ToString(),
+                Convert.ToString(prof.ProfileItemColor.ToArgb(), 16),
+                prof.Description
+            );
+        }
+
+        /// <summary>
+        /// CSVヘッダー整合性チェック
+        /// </summary>
+        /// <param name="header">ヘッダー</param>
+        public bool CheckCSVHeader(string header) {
+            return (header == CSVHeader) ? true : false;
+        }
+
+        /// <summary>
+        /// CSVフィールド数チェック
+        /// </summary>
+        /// <param name="data">CSVデータ</param>
+        public bool CheckCSVFieldCount(string data) {
+            string[] ary = data.Split(',');
+            return (ary.Length == ConnectProfileStruct.CSV_FIELD_CNT) ? true : false;
+        }
+
+        /// <summary>
+        /// CSVデータ整合性チェック
+        /// </summary>
+        /// <param name="data">CSVデータ</param>
+        public ConnectProfileStruct CheckCSVData(string data) {
+            ConnectProfileStruct prof = new ConnectProfileStruct();
+            string[] ary = data.Split(',');
+            int tmp;
+
+            // ホスト名
+            if (ary[0] != "") prof.HostName = ary[0];
+            else {
+                ConnectProfilePlugin.MessageBoxInvoke(ConnectProfilePlugin.Strings.GetString("Message.ConnectProfile.CSVImportInvalidHostName"), MessageBoxIcon.Error);
+                return null;
+            }
+
+            // プロトコル(
+            if (ary[1].ToLower() == "telnet") prof.Protocol = ConnectionMethod.Telnet;
+            else if (ary[1].ToLower() == "ssh1") prof.Protocol = ConnectionMethod.SSH1;
+            else if (ary[1].ToLower() == "ssh2") prof.Protocol = ConnectionMethod.SSH2;
+            else {
+                ConnectProfilePlugin.MessageBoxInvoke(ConnectProfilePlugin.Strings.GetString("Message.ConnectProfile.CSVImportInvalidProtocol"), MessageBoxIcon.Error);
+                return null;
+            }
+
+            // ポート
+            if (int.TryParse(ary[2], out tmp) == true) prof.Port = tmp;
+            else {
+                ConnectProfilePlugin.MessageBoxInvoke(ConnectProfilePlugin.Strings.GetString("Message.ConnectProfile.CSVImportInvalidPort"), MessageBoxIcon.Error);
+                return null;
+            }
+
+            // SSH認証方法(空白=Password)
+            if ((ary[3].ToLower() == "password") || (ary[3] == "")) prof.AuthType = AuthType.Password;
+            else if (ary[3].ToLower() == "publickey") prof.AuthType = AuthType.PublicKey;
+            else if (ary[3].ToLower() == "keyboardinteractive") prof.AuthType = AuthType.KeyboardInteractive;
+            else {
+                ConnectProfilePlugin.MessageBoxInvoke(ConnectProfilePlugin.Strings.GetString("Message.ConnectProfile.CSVImportInvalidAuthType"), MessageBoxIcon.Error);
+                return null;
+            }
+
+            // 秘密鍵ファイル/ユーザ名/パスワード
+            prof.KeyFile = ary[4];
+            prof.UserName = ary[5];
+            prof.Password = ary[6];
+
+            // 自動ログイン(空白=false)
+            if (ary[7].ToLower() == "true") prof.AutoLogin = true;
+            else if ((ary[7].ToLower() == "false") || ary[7] == "") prof.AutoLogin = false;
+            else {
+                ConnectProfilePlugin.MessageBoxInvoke(ConnectProfilePlugin.Strings.GetString("Message.ConnectProfile.CSVImportInvalidAutoLogin"), MessageBoxIcon.Error);
+                return null;
+            }
+
+            // プロンプト/実行コマンド/SU
+            prof.LoginPrompt = ary[8];
+            prof.PasswordPrompt = ary[9];
+            prof.ExecCommand = ary[10];
+            prof.SUUserName = ary[11];
+            prof.SUPassword = ary[12];
+
+            // SUコマンド
+            if (ary[13].ToLower() == "") prof.SUType = "";
+            else if (ary[13].ToLower() == ConnectProfilePlugin.Strings.GetString("Form.AddProfile._suTypeRadio1")) prof.SUType = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._suTypeRadio1");
+            else if (ary[13].ToLower() == ConnectProfilePlugin.Strings.GetString("Form.AddProfile._suTypeRadio2")) prof.SUType = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._suTypeRadio2");
+            else {
+                ConnectProfilePlugin.MessageBoxInvoke(ConnectProfilePlugin.Strings.GetString("Message.ConnectProfile.CSVImportInvalidSUType"), MessageBoxIcon.Error);
+                return null;
+            }
+
+            // 文字コード(空白=UTF8)
+            if (ary[14].ToLower() == "iso8859_1") prof.CharCode = EncodingType.ISO8859_1;
+            else if ((ary[14].ToLower() == "utf8") || (ary[14]) == "") prof.CharCode = EncodingType.UTF8;
+            else if (ary[14].ToLower() == "euc_jp") prof.CharCode = EncodingType.EUC_JP;
+            else if (ary[14].ToLower() == "shift_jis") prof.CharCode = EncodingType.SHIFT_JIS;
+            else if (ary[14].ToLower() == "gb2312") prof.CharCode = EncodingType.GB2312;
+            else if (ary[14].ToLower() == "big5") prof.CharCode = EncodingType.BIG5;
+            else if (ary[14].ToLower() == "euc_cn") prof.CharCode = EncodingType.EUC_CN;
+            else if (ary[14].ToLower() == "euc_kr") prof.CharCode = EncodingType.EUC_KR;
+            else if (ary[14].ToLower() == "utf8_latin") prof.CharCode = EncodingType.UTF8_Latin;
+            else if (ary[14].ToLower() == "oem850") prof.CharCode = EncodingType.OEM850;
+            else {
+                ConnectProfilePlugin.MessageBoxInvoke(ConnectProfilePlugin.Strings.GetString("Message.ConnectProfile.CSVImportInvalidCharCode"), MessageBoxIcon.Error);
+                return null;
+            }
+
+            // 改行コード(空白=CR)
+            if ((ary[15].ToLower() == "cr") || (ary[15] == "")) prof.NewLine = NewLine.CR;
+            else if (ary[15].ToLower() == "lf") prof.NewLine = NewLine.LF;
+            else if (ary[15].ToLower() == "crlf") prof.NewLine = NewLine.CRLF;
+            else {
+                ConnectProfilePlugin.MessageBoxInvoke(ConnectProfilePlugin.Strings.GetString("Message.ConnectProfile.CSVImportInvalidNewLine"), MessageBoxIcon.Error);
+                return null;
+            }
+
+            // TelnetNewLine(空白=true)
+            if ((ary[16].ToLower() == "true") || (ary[16] == "")) prof.TelnetNewLine = true;
+            else if (ary[16].ToLower() == "false") prof.TelnetNewLine = false;
+            else {
+                ConnectProfilePlugin.MessageBoxInvoke(ConnectProfilePlugin.Strings.GetString("Message.ConnectProfile.CSVImportInvalidTelnetNewLine"), MessageBoxIcon.Error);
+                return null;
+            }
+
+            // ターミナル種類(空白=XTerm)
+            if (ary[17].ToLower() == "kterm") prof.TerminalType = TerminalType.KTerm;
+            else if (ary[17].ToLower() == "vt100") prof.TerminalType = TerminalType.VT100;
+            else if ((ary[17].ToLower() == "xterm") || (ary[17] == "")) prof.TerminalType = TerminalType.XTerm;
+            else {
+                ConnectProfilePlugin.MessageBoxInvoke(ConnectProfilePlugin.Strings.GetString("Message.ConnectProfile.CSVImportInvalidTerminalType"), MessageBoxIcon.Error);
+                return null;
+            }
+
+            // フォント色/背景色
+            prof.TerminalFontColor = ParseUtil.ParseColor(ary[18].ToLower(), Color.White);
+            prof.TerminalBGColor = ParseUtil.ParseColor(ary[19].ToLower(), Color.Black);
+
+            // コマンド発行間隔(空白=200ms)
+            if (ary[20] == "") prof.CommandSendInterval = 200;
+            else if (int.TryParse(ary[20], out tmp) == true) prof.CommandSendInterval = tmp;
+            else {
+                ConnectProfilePlugin.MessageBoxInvoke(ConnectProfilePlugin.Strings.GetString("Message.ConnectProfile.CSVImportCommandSendInterval"), MessageBoxIcon.Error);
+                return null;
+            }
+
+            // プロンプト受信タイムアウト(空白=5000ms)
+            if (ary[21] == "") prof.PromptRecvTimeout = 5000;
+            else if (int.TryParse(ary[21], out tmp) == true) prof.PromptRecvTimeout = tmp;
+            else {
+                ConnectProfilePlugin.MessageBoxInvoke(ConnectProfilePlugin.Strings.GetString("Message.ConnectProfile.CSVImportPromptRecvTimeout"), MessageBoxIcon.Error);
+                return null;
+            }
+
+            // 項目色
+            prof.ProfileItemColor = ParseUtil.ParseColor(ary[22].ToLower(), Color.Black);
+
+            // 説明
+            prof.Description = ary[23];
+
+            return prof;
+        }
+
+        /// <summary>
+        /// CSVヘッダー
+        /// </summary>
+        public string CSVHeader {
+            get {
+                return string.Format(
+                    ConnectProfileStruct.FMT_CSV,
+                    "HOSTNAME",
+                    "PROTOCOL",
+                    "PORT",
+                    "AUTH_TYPE",
+                    "KEY_FILE",
+                    "USERNAME",
+                    "PASSWORD",
+                    "AUTO_LOGIN",
+                    "LOGIN_PROMPT",
+                    "PASSWORD_PROMPT",
+                    "EXEC_COMMAND",
+                    "SU_USERNAME",
+                    "SU_PASSWORD",
+                    "SU_TYPE",
+                    "CHAR_CODE",
+                    "NEWLINE",
+                    "TELNET_NEWLINE",
+                    "TERMINAL_TYPE",
+                    "TERMINAL_FONTCOLOR",
+                    "TERMINAL_BGCOLOR",
+                    "COMMAND_SEND_INTERVAL",
+                    "PROMPT_RECV_TIMEOUT",
+                    "PROFILE_ITEM_COLOR",
+                    "DESCRIPTION"
+                );
+            }
+        }
+    }
+
+
+
+
+    /// <summary>
+    /// ターミナル接続クラス
+    /// </summary>
+    internal class ConnectProfileTerminal {
+        // メンバー変数
+        private ConnectProfileStruct _prof;
+        private ITerminalSession _terminalSession;
+
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        /// <param name="prof">プロファイル</param>
+        public ConnectProfileTerminal(ConnectProfileStruct prof) {
+            _prof = prof;
+        }
+
+        /// <summary>
+        /// 接続
+        /// </summary>
+        public void Connect() {
+            ITCPParameter tcp = null;
+
+            // プロトコル
+            if (_prof.Protocol == ConnectionMethod.Telnet) {
+                // Telnet
+                tcp = ConnectProfilePlugin.Instance.ProtocolService.CreateDefaultTelnetParameter();
+                tcp.Destination = _prof.HostName;
+                tcp.Port = _prof.Port;
+                ITelnetParameter telnetParameter = null;
+                telnetParameter = (ITelnetParameter)tcp.GetAdapter(typeof(ITelnetParameter));
+                if (telnetParameter != null) telnetParameter.TelnetNewLine = _prof.TelnetNewLine;
+            } else if ((_prof.Protocol == ConnectionMethod.SSH1) || (_prof.Protocol == ConnectionMethod.SSH2)) {
+                // SSH
+                ISSHLoginParameter ssh = ConnectProfilePlugin.Instance.ProtocolService.CreateDefaultSSHParameter();
+                tcp = (ITCPParameter)ssh.GetAdapter(typeof(ITCPParameter));
+                tcp.Destination = _prof.HostName;
+                tcp.Port = _prof.Port;
+                ssh.Method = (_prof.Protocol == ConnectionMethod.SSH1) ? SSHProtocol.SSH1 : SSHProtocol.SSH2;
+                ssh.Account = _prof.UserName;
+                ssh.AuthenticationType = ConvertAuth(_prof.AuthType);
+                ssh.PasswordOrPassphrase = _prof.Password;
+                ssh.IdentityFileName = _prof.KeyFile;
+                ssh.LetUserInputPassword = (_prof.AutoLogin == true) ? false : true;
+            }
+
+            // ターミナルオプション取得
+            ITerminalEmulatorOptions terminalOptions = ConnectProfilePlugin.Instance.TerminalEmulatorService.TerminalEmulatorOptions;
+
+            // 表示プロファイル(背景/フォント色以外はターミナルオプション値を設定)
+            RenderProfile render = new RenderProfile();
+            render.ForeColor = _prof.TerminalFontColor;
+            render.BackColor = _prof.TerminalBGColor;
+            render.FontSize = terminalOptions.Font.Size;
+            render.FontName = terminalOptions.Font.Name;
+            render.CJKFontName = terminalOptions.CJKFont.Name;
+            render.UseClearType = terminalOptions.UseClearType;
+            render.EnableBoldStyle = terminalOptions.EnableBoldStyle;
+            render.ForceBoldStyle = terminalOptions.ForceBoldStyle;
+            render.LineSpacing = terminalOptions.LineSpacing;
+            render.ESColorSet = (EscapesequenceColorSet)terminalOptions.EscapeSequenceColorSet.Clone();
+            render.DarkenEsColorForBackground = terminalOptions.DarkenEsColorForBackground;
+            render.BackgroundImageFileName = terminalOptions.BackgroundImageFileName;
+            render.ImageStyle = terminalOptions.ImageStyle;
+
+            // TerminalSettings(表示プロファイル/改行コード/文字コード)
+            ITerminalSettings terminalSettings = ConnectProfilePlugin.Instance.TerminalEmulatorService.CreateDefaultTerminalSettings(_prof.HostName, null);
+            terminalSettings.BeginUpdate();
+            terminalSettings.RenderProfile = render;
+            terminalSettings.TransmitNL = _prof.NewLine;
+            terminalSettings.Encoding = _prof.CharCode;
+            terminalSettings.LocalEcho = false;
+            terminalSettings.EndUpdate();
+
+            // TerminalParameter
+            ITerminalParameter terminalParam = (ITerminalParameter)tcp.GetAdapter(typeof(ITerminalParameter));
+
+            // ターミナルサイズ(これを行わないとPoderosa起動直後のOnReceptionが何故か機能しない, 行わない場合は2回目以降の接続時は正常)
+            IViewManager viewManager = CommandTargetUtil.AsWindow(ConnectProfilePlugin.Instance.WindowManager.ActiveWindow).ViewManager;
+            IContentReplaceableView contentReplaceableView = (IContentReplaceableView)viewManager.GetCandidateViewForNewDocument().GetAdapter(typeof(IContentReplaceableView));
+            TerminalControl terminalControl = (TerminalControl)contentReplaceableView.GetCurrentContent().GetAdapter(typeof(TerminalControl));
+            if (terminalControl != null) {
+                Size size = terminalControl.CalcTerminalSize(terminalSettings.RenderProfile);
+                terminalParam.SetTerminalSize(size.Width, size.Height);
+            }
+
+            // 接続(セッションオープン)
+            _terminalSession = (ITerminalSession)ConnectProfilePlugin.Instance.WindowManager.ActiveWindow.AsForm().Invoke(new OpenSessionDelegate(InvokeOpenSessionOrNull), terminalParam, terminalSettings);
+
+            // 自動ログイン/SU/実行コマンド
+            if (_terminalSession != null) {
+                // 受信データオブジェクト作成(ユーザからのキーボード入力が不可)
+                ReceptionData pool = new ReceptionData();
+                _terminalSession.Terminal.StartModalTerminalTask(pool);
+
+                // Telnet自動ログイン
+                if ((_prof.AutoLogin == true) && (_prof.Protocol == ConnectionMethod.Telnet)) {
+                    if (TelnetAutoLogin() != true) return;
+                }
+
+                // SU
+                if ((_prof.AutoLogin == true) && (_prof.SUUserName != "")) {
+                    if (SUSwitch() != true) return;
+                }
+
+                // 実行コマンド
+                if ((_prof.AutoLogin == true) && (_prof.ExecCommand != "")) {
+                    if (ExecCommand() != true) return;
+                }
+
+                // 受信データオブジェクト定義解除(ユーザからのキーボード入力を許可)
+                _terminalSession.Terminal.EndModalTerminalTask();
+            }
+        }
+
+        /// <summary>
+        /// SSH認証オブジェクト変換
+        /// </summary>
+        /// <param name="t">SSH認証方法</param>
+        private AuthenticationType ConvertAuth(AuthType t) {
+            return t == AuthType.Password ? AuthenticationType.Password : t == AuthType.PublicKey ? AuthenticationType.PublicKey : AuthenticationType.KeyboardInteractive;
+        }
+
+        /// <summary>
+        /// Telnet自動ログイン
+        /// </summary>
+        private bool TelnetAutoLogin() {
+            // ユーザ名
+            if (WaitRecv(_prof.LoginPrompt) != true) {
+                ConnectProfilePlugin.MessageBoxInvoke(ConnectProfilePlugin.Strings.GetString("Message.Connect.LoginPromptNotFound"), MessageBoxIcon.Warning);
+                _terminalSession.Terminal.EndModalTerminalTask();
+                return false;
+            }
+            TransmitLn(_prof.UserName);
+
+            // パスワード
+            if (WaitRecv(_prof.PasswordPrompt) != true) {
+                ConnectProfilePlugin.MessageBoxInvoke(ConnectProfilePlugin.Strings.GetString("Message.Connect.PasswordPromptNotFound"), MessageBoxIcon.Warning);
+                _terminalSession.Terminal.EndModalTerminalTask();
+                return false;
+            }
+            TransmitLn(_prof.Password);
+
+            return true;
+        }
+
+        /// <summary>
+        /// SUスイッチ
+        /// </summary>
+        private bool SUSwitch() {
+            // ユーザ名
+            TransmitLn(string.Format("{0} {1}", _prof.SUType, _prof.SUUserName));
+
+            // パスワード
+            if (WaitRecv(_prof.PasswordPrompt) != true) {
+                ConnectProfilePlugin.MessageBoxInvoke(ConnectProfilePlugin.Strings.GetString("Message.Connect.PasswordPromptNotFound"), MessageBoxIcon.Warning);
+                _terminalSession.Terminal.EndModalTerminalTask();
+                return false;
+            }
+            TransmitLn(_prof.SUPassword);
+
+            return true;
+        }
+
+        /// <summary>
+        /// 実行コマンド
+        /// </summary>
+        private bool ExecCommand() {
+            TransmitLn(_prof.ExecCommand);
+
+            return true;
+        }
+
+        /// <summary>
+        /// 指定文字列受信待機
+        /// </summary>
+        /// <param name="searchstr">受信待機対象文字列</param>
+        private bool WaitRecv(string searchstr) {
+            Thread.Sleep(_prof.CommandSendInterval);
+            Regex RegExp = new Regex(searchstr, (RegexOptions.Multiline | RegexOptions.IgnoreCase));
+            string data = "";
+
+            while (RegExp.IsMatch(data) == false) {
+                Thread.Sleep(10);
+                data = ReceiveData(_prof.PromptRecvTimeout);
+                if (data == null) break;
+            }
+
+            return (data == null) ? false : true;
+        }
+
+        /// <summary>
+        /// 文字列送信
+        /// </summary>
+        /// <param name="data">送信文字列</param>
+        public void Transmit(string data) {
+            Thread.Sleep(_prof.CommandSendInterval);
+            _terminalSession.TerminalTransmission.SendString(data.ToCharArray());
+        }
+
+        /// <summary>
+        /// 文字列送信(改行あり)
+        /// </summary>
+        /// <param name="data">送信文字列</param>
+        public void TransmitLn(string data) {
+            Thread.Sleep(_prof.CommandSendInterval);
+            if (data.Length > 0) _terminalSession.TerminalTransmission.SendString(data.ToCharArray());
+            _terminalSession.TerminalTransmission.SendLineBreak();
+        }
+
+        /// <summary>
+        /// 受信データ読み取り
+        /// </summary>
+        public string ReceiveData() {
+            return GetCurrentReceptionPool().ReadAll();
+        }
+
+        /// <summary>
+        /// 受信データ読み取り(タイムアウト設定あり)
+        /// </summary>
+        /// <param name="timeoutMillisecs">タイムアウト(ms)</param>
+        public string ReceiveData(int timeoutMillisecs) {
+            return GetCurrentReceptionPool().ReadAll(timeoutMillisecs);
+        }
+
+        /// <summary>
+        /// GetCurrentReceptionPool
+        /// </summary>
+        private ReceptionData GetCurrentReceptionPool() {
+            return (ReceptionData)_terminalSession.Terminal.CurrentModalTerminalTask.GetAdapter(typeof(ReceptionData));
+        }
+
+        /// <summary>
+        /// ターミナルセッションDelegate
+        /// </summary>
+        /// <param name="tp">ターミナルパラメータ</param>
+        /// <param name="ts">ターミナルセッティング</param>
+        private delegate ITerminalSession OpenSessionDelegate(ITerminalParameter tp, ITerminalSettings ts);
+        /// <summary>
+        /// ターミナルセッションInvoke
+        /// </summary>
+        /// <param name="tp">ターミナルパラメータ</param>
+        /// <param name="ts">ターミナルセッティング</param>
+        private static ITerminalSession InvokeOpenSessionOrNull(ITerminalParameter tp, ITerminalSettings ts) {
+            try {
+                ITerminalSessionsService ss = ConnectProfilePlugin.Instance.TerminalSessionsService;
+                ITerminalSession newsession = ss.TerminalSessionStartCommand.StartTerminalSession(ConnectProfilePlugin.Instance.WindowManager.ActiveWindow, tp, ts);
+                return (newsession == null) ? null : newsession;
+            } catch (Exception ex) {
+                RuntimeUtil.ReportException(ex);
+                return null;
+            }
+        }
+    }
+
+
+
+
+    /// <summary>
+    /// 受信文字列格納保持クラス
+    /// </summary>
+    internal class ReceptionData : IModalCharacterTask {
+        // メンバー変数
+        private IModalTerminalTaskSite _site;
+        private StringBuilder _buffer;
+        private readonly object _signal = new object();
+        private bool _closed;
+
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        public void InitializeModelTerminalTask(IModalTerminalTaskSite site, IByteAsyncInputStream default_handler, ITerminalConnection connection) {
+            _site = site;
+            _buffer = new StringBuilder();
+            _closed = false;
+        }
+
+        /// <summary>
+        /// GetAdapter
+        /// </summary>
+        public IAdaptable GetAdapter(Type adapter) {
+            return ConnectProfilePlugin.Instance.PoderosaWorld.AdapterManager.GetAdapter(this, adapter);
+        }
+
+        /// <summary>
+        /// OnReception
+        /// </summary>
+        public void OnReception(ByteDataFragment data) {
+        }
+
+        /// <summary>
+        /// OnNormalTermination
+        /// </summary>
+        public void OnNormalTermination() {
+            lock (_signal) {
+                if (!_closed) _site.Cancel(null);
+            }
+        }
+
+        /// <summary>
+        /// OnAbnormalTermination
+        /// </summary>
+        public void OnAbnormalTermination(string message) {
+            lock (_signal) {
+                if (!_closed) _site.Cancel(null);
+            }
+        }
+
+        /// <summary>
+        /// NotifyEndOfPacket
+        /// </summary>
+        public void NotifyEndOfPacket() {
+            lock (_signal) {
+                if (!_closed) Monitor.PulseAll(_signal);
+            }
+        }
+
+        /// <summary>
+        /// Close
+        /// </summary>
+        public void Close() {
+            lock (_signal) {
+                if (!_closed) {
+                    _closed = true;
+                    Monitor.PulseAll(_signal);
+                    _site.Complete();
+                }
+            }
+        }
+
+        /// <summary>
+        /// 受信データ読み取り
+        /// </summary>
+        public string ReadAll() {
+            return ReadAllMain(false, 0);
+        }
+
+        /// <summary>
+        /// 受信データ読み取り(タイムアウトあり)
+        /// </summary>
+        /// <param name="timeoutMillisecs">タイムアウト(ms)</param>
+        public string ReadAll(int timeoutMillisecs) {
+            if (timeoutMillisecs < 0) throw new ArgumentException("Invalid timeout", "timeoutMillisecs");
+            return ReadAllMain(true, timeoutMillisecs);
+        }
+
+        /// <summary>
+        /// 受信データ読み取り(実体)
+        /// </summary>
+        /// <param name="hasTimeout">タイムアウト設定</param>
+        /// <param name="timeoutMillisecs">タイムアウト(ms)</param>
+        private string ReadAllMain(bool hasTimeout, int timeoutMillisecs) {
+            lock (_signal) {
+                if (_buffer.Length == 0) {
+                    if (_closed) {
+                        if (hasTimeout) return null;
+                    } else {
+                        if (hasTimeout) {
+                            bool signaled = Monitor.Wait(_signal, timeoutMillisecs);
+                            if (!signaled && _buffer.Length == 0) return null;
+                        } else {
+                            Monitor.Wait(_signal);
+                        }
+                    }
+                }
+            }
+
+            string r;
+            lock (_buffer) {
+                r = _buffer.ToString();
+                _buffer.Remove(0, _buffer.Length);
+            }
+            return r;
+        }
+
+        /// <summary>
+        /// 受信データ格納保持
+        /// </summary>
+        public void ProcessChar(char ch) {
+            if (Char.IsControl(ch) && ch != '\n') return;
+            lock (_buffer) {
+                _buffer.Append(ch);
+            }
+        }
+
+        /// <summary>
+        /// Caption
+        /// </summary>
+        public string Caption {
+            get { return "CONNECTPROFILE"; }
+        }
+
+        /// <summary>
+        /// ShowInputInTerminal
+        /// </summary>
+        public bool ShowInputInTerminal {
+            get { return true; }
+        }
+    }
+}

--- a/ConnectProfile/ConnectProfile.csproj
+++ b/ConnectProfile/ConnectProfile.csproj
@@ -1,0 +1,110 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A6A3F2DF-24B0-4471-88C2-1898167A976E}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Poderosa.ConnectProfile</RootNamespace>
+    <AssemblyName>Poderosa.ConnectProfile</AssemblyName>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>..\bin\Debug\Poderosa.ConnectProfile.XML</DocumentationFile>
+    <NoWarn>1591</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>..\bin\Release\Poderosa.ConnectProfile.XML</DocumentationFile>
+    <NoWarn>1591</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Commands.cs" />
+    <Compile Include="ConnectProfileList.cs" />
+    <Compile Include="ProfileEditForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="ProfileEditForm.Designer.cs">
+      <DependentUpon>ProfileEditForm.cs</DependentUpon>
+    </Compile>
+    <Compile Include="ConnectProfileForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="ConnectProfileForm.Designer.cs">
+      <DependentUpon>ConnectProfileForm.cs</DependentUpon>
+    </Compile>
+    <Compile Include="ConnectProfilePlugin.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Core.csproj">
+      <Project>{8a416f19-9031-44a1-b225-bcb31a6bc6a7}</Project>
+      <Name>Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Granados\Granados.csproj">
+      <Project>{9d114b8b-e62c-4fbf-b281-0227755c8091}</Project>
+      <Name>Granados</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Plugin\Plugin.csproj">
+      <Project>{d84b661b-503e-4c22-892b-7499b72c7e04}</Project>
+      <Name>Plugin</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Protocols\Protocols.csproj">
+      <Project>{04f18da5-bf47-48a3-9b8b-b6b93dcba875}</Project>
+      <Name>Protocols</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\TerminalEmulator\TerminalEmulator.csproj">
+      <Project>{7f80731c-443a-4533-90d1-1643a5c1364e}</Project>
+      <Name>TerminalEmulator</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\TerminalSession\TerminalSession.csproj">
+      <Project>{4554e83a-2a00-47e2-ab5b-14a228895c17}</Project>
+      <Name>TerminalSession</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\UI\UI.csproj">
+      <Project>{9568d8ac-7b55-42e0-acd7-204e397e7048}</Project>
+      <Name>UI</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="ProfileEditForm.resx">
+      <DependentUpon>ProfileEditForm.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="ConnectProfileForm.resx">
+      <DependentUpon>ConnectProfileForm.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="strings.resx" />
+    <EmbeddedResource Include="strings_ja.resx" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/ConnectProfile/ConnectProfileForm.Designer.cs
+++ b/ConnectProfile/ConnectProfileForm.Designer.cs
@@ -1,0 +1,433 @@
+﻿namespace Poderosa.ConnectProfile {
+    partial class ConnectProfileForm {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing) {
+            if (disposing && (components != null)) {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent() {
+            this.components = new System.ComponentModel.Container();
+            System.Windows.Forms.ListViewItem listViewItem1 = new System.Windows.Forms.ListViewItem("");
+            System.Windows.Forms.ListViewItem listViewItem2 = new System.Windows.Forms.ListViewItem("");
+            System.Windows.Forms.ListViewItem listViewItem3 = new System.Windows.Forms.ListViewItem("");
+            System.Windows.Forms.ListViewItem listViewItem4 = new System.Windows.Forms.ListViewItem("");
+            System.Windows.Forms.ListViewItem listViewItem5 = new System.Windows.Forms.ListViewItem("");
+            System.Windows.Forms.ListViewItem listViewItem6 = new System.Windows.Forms.ListViewItem("");
+            System.Windows.Forms.ListViewItem listViewItem7 = new System.Windows.Forms.ListViewItem("");
+            System.Windows.Forms.ListViewItem listViewItem8 = new System.Windows.Forms.ListViewItem("");
+            System.Windows.Forms.ListViewItem listViewItem9 = new System.Windows.Forms.ListViewItem("");
+            System.Windows.Forms.ListViewItem listViewItem10 = new System.Windows.Forms.ListViewItem("");
+            System.Windows.Forms.ListViewItem listViewItem11 = new System.Windows.Forms.ListViewItem("");
+            System.Windows.Forms.ListViewItem listViewItem12 = new System.Windows.Forms.ListViewItem("");
+            System.Windows.Forms.ListViewItem listViewItem13 = new System.Windows.Forms.ListViewItem("");
+            System.Windows.Forms.ListViewItem listViewItem14 = new System.Windows.Forms.ListViewItem("");
+            System.Windows.Forms.ListViewItem listViewItem15 = new System.Windows.Forms.ListViewItem("");
+            this._profileListView = new System.Windows.Forms.ListView();
+            this._hostNameColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this._userNameColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this._autoLoginColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this._protocolColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this._portColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this._suSwitchColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this._charCodeColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this._newLineColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this._execCommandColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this._terminalBGColorColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this._descriptionColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this._filterLabel = new System.Windows.Forms.Label();
+            this._okButton = new System.Windows.Forms.Button();
+            this._cancelButton = new System.Windows.Forms.Button();
+            this._addProfileButton = new System.Windows.Forms.Button();
+            this._delProfileButton = new System.Windows.Forms.Button();
+            this._csvExportButton = new System.Windows.Forms.Button();
+            this._csvImportButton = new System.Windows.Forms.Button();
+            this._profileCountLabel = new System.Windows.Forms.Label();
+            this._editProfileButton = new System.Windows.Forms.Button();
+            this._checkAllOffButton = new System.Windows.Forms.Button();
+            this._filterTimer = new System.Windows.Forms.Timer(this.components);
+            this._selectedProfileCountLabel = new System.Windows.Forms.Label();
+            this._displaySelectedOnlyCheck = new System.Windows.Forms.CheckBox();
+            this._saveCSVFileDialog = new System.Windows.Forms.SaveFileDialog();
+            this._openCSVFileDialog = new System.Windows.Forms.OpenFileDialog();
+            this._hintLabel = new System.Windows.Forms.Label();
+            this._copyButton = new System.Windows.Forms.Button();
+            this._filterTextBox = new Poderosa.UI.WaterMarkTextBox();
+            this.SuspendLayout();
+            // 
+            // _profileListView
+            // 
+            this._profileListView.AllowColumnReorder = true;
+            this._profileListView.CheckBoxes = true;
+            this._profileListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this._hostNameColumn,
+            this._userNameColumn,
+            this._autoLoginColumn,
+            this._protocolColumn,
+            this._portColumn,
+            this._suSwitchColumn,
+            this._charCodeColumn,
+            this._newLineColumn,
+            this._execCommandColumn,
+            this._terminalBGColorColumn,
+            this._descriptionColumn});
+            this._profileListView.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this._profileListView.FullRowSelect = true;
+            this._profileListView.GridLines = true;
+            this._profileListView.HideSelection = false;
+            listViewItem1.StateImageIndex = 0;
+            listViewItem2.StateImageIndex = 0;
+            listViewItem3.StateImageIndex = 0;
+            listViewItem4.StateImageIndex = 0;
+            listViewItem5.StateImageIndex = 0;
+            listViewItem6.StateImageIndex = 0;
+            listViewItem7.StateImageIndex = 0;
+            listViewItem8.StateImageIndex = 0;
+            listViewItem9.StateImageIndex = 0;
+            listViewItem10.StateImageIndex = 0;
+            listViewItem11.StateImageIndex = 0;
+            listViewItem12.StateImageIndex = 0;
+            listViewItem13.StateImageIndex = 0;
+            listViewItem14.StateImageIndex = 0;
+            listViewItem15.StateImageIndex = 0;
+            this._profileListView.Items.AddRange(new System.Windows.Forms.ListViewItem[] {
+            listViewItem1,
+            listViewItem2,
+            listViewItem3,
+            listViewItem4,
+            listViewItem5,
+            listViewItem6,
+            listViewItem7,
+            listViewItem8,
+            listViewItem9,
+            listViewItem10,
+            listViewItem11,
+            listViewItem12,
+            listViewItem13,
+            listViewItem14,
+            listViewItem15});
+            this._profileListView.Location = new System.Drawing.Point(0, 79);
+            this._profileListView.MultiSelect = false;
+            this._profileListView.Name = "_profileListView";
+            this._profileListView.ShowItemToolTips = true;
+            this._profileListView.Size = new System.Drawing.Size(780, 271);
+            this._profileListView.Sorting = System.Windows.Forms.SortOrder.Ascending;
+            this._profileListView.TabIndex = 1;
+            this._profileListView.UseCompatibleStateImageBehavior = false;
+            this._profileListView.View = System.Windows.Forms.View.Details;
+            this._profileListView.ColumnClick += new System.Windows.Forms.ColumnClickEventHandler(this._profileListView_ColumnClick);
+            this._profileListView.ItemCheck += new System.Windows.Forms.ItemCheckEventHandler(this._profileListView_ItemCheck);
+            this._profileListView.ItemChecked += new System.Windows.Forms.ItemCheckedEventHandler(this._profileListView_ItemChecked);
+            this._profileListView.MouseDown += new System.Windows.Forms.MouseEventHandler(this._profileListView_MouseDown);
+            // 
+            // _hostNameColumn
+            // 
+            this._hostNameColumn.Text = "_hostNameColumn";
+            this._hostNameColumn.Width = 105;
+            // 
+            // _userNameColumn
+            // 
+            this._userNameColumn.Text = "_userNameColumn";
+            this._userNameColumn.Width = 105;
+            // 
+            // _autoLoginColumn
+            // 
+            this._autoLoginColumn.Text = "_autoLoginColumn";
+            this._autoLoginColumn.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this._autoLoginColumn.Width = 103;
+            // 
+            // _protocolColumn
+            // 
+            this._protocolColumn.Text = "_protocolColumn";
+            this._protocolColumn.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this._protocolColumn.Width = 95;
+            // 
+            // _portColumn
+            // 
+            this._portColumn.Text = "_portColumn";
+            this._portColumn.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            this._portColumn.Width = 74;
+            // 
+            // _suSwitchColumn
+            // 
+            this._suSwitchColumn.Text = "_suSwitchColumn";
+            this._suSwitchColumn.Width = 100;
+            // 
+            // _charCodeColumn
+            // 
+            this._charCodeColumn.Text = "_charCodeColumn";
+            this._charCodeColumn.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this._charCodeColumn.Width = 102;
+            // 
+            // _newLineColumn
+            // 
+            this._newLineColumn.Text = "_newLineColumn";
+            this._newLineColumn.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this._newLineColumn.Width = 95;
+            // 
+            // _execCommandColumn
+            // 
+            this._execCommandColumn.Text = "_execCommandColumn";
+            this._execCommandColumn.Width = 128;
+            // 
+            // _terminalBGColorColumn
+            // 
+            this._terminalBGColorColumn.Text = "_terminalBGColorColumn";
+            this._terminalBGColorColumn.Width = 138;
+            // 
+            // _descriptionColumn
+            // 
+            this._descriptionColumn.Text = "_descriptionColumn";
+            this._descriptionColumn.Width = 95;
+            // 
+            // _filterLabel
+            // 
+            this._filterLabel.AutoSize = true;
+            this._filterLabel.Location = new System.Drawing.Point(9, 15);
+            this._filterLabel.Name = "_filterLabel";
+            this._filterLabel.Size = new System.Drawing.Size(60, 12);
+            this._filterLabel.TabIndex = 1;
+            this._filterLabel.Text = "_filterLabel";
+            // 
+            // _okButton
+            // 
+            this._okButton.Location = new System.Drawing.Point(241, 10);
+            this._okButton.Name = "_okButton";
+            this._okButton.Size = new System.Drawing.Size(75, 23);
+            this._okButton.TabIndex = 2;
+            this._okButton.Text = "_okButton";
+            this._okButton.UseVisualStyleBackColor = true;
+            this._okButton.Click += new System.EventHandler(this._okButton_Click);
+            // 
+            // _cancelButton
+            // 
+            this._cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this._cancelButton.Location = new System.Drawing.Point(322, 10);
+            this._cancelButton.Name = "_cancelButton";
+            this._cancelButton.Size = new System.Drawing.Size(75, 23);
+            this._cancelButton.TabIndex = 3;
+            this._cancelButton.Text = "_cancelButton";
+            this._cancelButton.UseVisualStyleBackColor = true;
+            this._cancelButton.Click += new System.EventHandler(this._cancelButton_Click);
+            // 
+            // _addProfileButton
+            // 
+            this._addProfileButton.Location = new System.Drawing.Point(534, 10);
+            this._addProfileButton.Name = "_addProfileButton";
+            this._addProfileButton.Size = new System.Drawing.Size(75, 23);
+            this._addProfileButton.TabIndex = 5;
+            this._addProfileButton.Text = "_addProfileButton";
+            this._addProfileButton.UseVisualStyleBackColor = true;
+            this._addProfileButton.Click += new System.EventHandler(this._addProfileButton_Click);
+            // 
+            // _delProfileButton
+            // 
+            this._delProfileButton.Location = new System.Drawing.Point(696, 10);
+            this._delProfileButton.Name = "_delProfileButton";
+            this._delProfileButton.Size = new System.Drawing.Size(75, 23);
+            this._delProfileButton.TabIndex = 7;
+            this._delProfileButton.Text = "_delProfileButton";
+            this._delProfileButton.UseVisualStyleBackColor = true;
+            this._delProfileButton.Click += new System.EventHandler(this._delProfileButton_Click);
+            // 
+            // _csvExportButton
+            // 
+            this._csvExportButton.Location = new System.Drawing.Point(615, 39);
+            this._csvExportButton.Name = "_csvExportButton";
+            this._csvExportButton.Size = new System.Drawing.Size(75, 23);
+            this._csvExportButton.TabIndex = 9;
+            this._csvExportButton.Text = "_csvExportButton";
+            this._csvExportButton.UseVisualStyleBackColor = true;
+            this._csvExportButton.Click += new System.EventHandler(this._csvExportButton_Click);
+            // 
+            // _csvImportButton
+            // 
+            this._csvImportButton.Location = new System.Drawing.Point(696, 39);
+            this._csvImportButton.Name = "_csvImportButton";
+            this._csvImportButton.Size = new System.Drawing.Size(75, 23);
+            this._csvImportButton.TabIndex = 10;
+            this._csvImportButton.Text = "_csvImportButton";
+            this._csvImportButton.UseVisualStyleBackColor = true;
+            this._csvImportButton.Click += new System.EventHandler(this._csvImportButton_Click);
+            // 
+            // _profileCountLabel
+            // 
+            this._profileCountLabel.AutoSize = true;
+            this._profileCountLabel.Location = new System.Drawing.Point(9, 44);
+            this._profileCountLabel.Name = "_profileCountLabel";
+            this._profileCountLabel.Size = new System.Drawing.Size(98, 12);
+            this._profileCountLabel.TabIndex = 10;
+            this._profileCountLabel.Text = "_profileCountLabel";
+            // 
+            // _editProfileButton
+            // 
+            this._editProfileButton.Location = new System.Drawing.Point(615, 10);
+            this._editProfileButton.Name = "_editProfileButton";
+            this._editProfileButton.Size = new System.Drawing.Size(75, 23);
+            this._editProfileButton.TabIndex = 6;
+            this._editProfileButton.Text = "_editProfileButton";
+            this._editProfileButton.UseVisualStyleBackColor = true;
+            this._editProfileButton.Click += new System.EventHandler(this._editProfileButton_Click);
+            // 
+            // _checkAllOffButton
+            // 
+            this._checkAllOffButton.Location = new System.Drawing.Point(413, 10);
+            this._checkAllOffButton.Name = "_checkAllOffButton";
+            this._checkAllOffButton.Size = new System.Drawing.Size(106, 23);
+            this._checkAllOffButton.TabIndex = 4;
+            this._checkAllOffButton.Text = "_checkAllOffButton";
+            this._checkAllOffButton.UseVisualStyleBackColor = true;
+            this._checkAllOffButton.Click += new System.EventHandler(this._checkAllOffButton_Click);
+            // 
+            // _filterTimer
+            // 
+            this._filterTimer.Tick += new System.EventHandler(this._filterTime_Tick);
+            // 
+            // _selectedProfileCountLabel
+            // 
+            this._selectedProfileCountLabel.AutoSize = true;
+            this._selectedProfileCountLabel.Location = new System.Drawing.Point(130, 44);
+            this._selectedProfileCountLabel.Name = "_selectedProfileCountLabel";
+            this._selectedProfileCountLabel.Size = new System.Drawing.Size(142, 12);
+            this._selectedProfileCountLabel.TabIndex = 16;
+            this._selectedProfileCountLabel.Text = "_selectedProfileCountLabel";
+            // 
+            // _displaySelectedOnlyCheck
+            // 
+            this._displaySelectedOnlyCheck.AutoSize = true;
+            this._displaySelectedOnlyCheck.Location = new System.Drawing.Point(241, 43);
+            this._displaySelectedOnlyCheck.Name = "_displaySelectedOnlyCheck";
+            this._displaySelectedOnlyCheck.Size = new System.Drawing.Size(163, 16);
+            this._displaySelectedOnlyCheck.TabIndex = 11;
+            this._displaySelectedOnlyCheck.Text = "_displaySelectedOnlyCheck";
+            this._displaySelectedOnlyCheck.UseVisualStyleBackColor = true;
+            this._displaySelectedOnlyCheck.CheckedChanged += new System.EventHandler(this._displaySelectedOnlyCheck_CheckedChanged);
+            // 
+            // _saveCSVFileDialog
+            // 
+            this._saveCSVFileDialog.DefaultExt = "csv";
+            // 
+            // _openCSVFileDialog
+            // 
+            this._openCSVFileDialog.DefaultExt = "csv";
+            // 
+            // _hintLabel
+            // 
+            this._hintLabel.AutoSize = true;
+            this._hintLabel.Location = new System.Drawing.Point(9, 62);
+            this._hintLabel.Name = "_hintLabel";
+            this._hintLabel.Size = new System.Drawing.Size(55, 12);
+            this._hintLabel.TabIndex = 18;
+            this._hintLabel.Text = "_hintLabel";
+            // 
+            // _copyButton
+            // 
+            this._copyButton.Location = new System.Drawing.Point(534, 39);
+            this._copyButton.Name = "_copyButton";
+            this._copyButton.Size = new System.Drawing.Size(75, 23);
+            this._copyButton.TabIndex = 8;
+            this._copyButton.Text = "_copyButton";
+            this._copyButton.UseVisualStyleBackColor = true;
+            this._copyButton.Click += new System.EventHandler(this._copyButton_Click);
+            // 
+            // _filterTextBox
+            // 
+            this._filterTextBox.Location = new System.Drawing.Point(52, 12);
+            this._filterTextBox.Name = "_filterTextBox";
+            this._filterTextBox.Size = new System.Drawing.Size(183, 19);
+            this._filterTextBox.TabIndex = 0;
+            this._filterTextBox.WaterMarkAlsoFocus = true;
+            this._filterTextBox.WaterMarkColor = System.Drawing.Color.Gray;
+            this._filterTextBox.WaterMarkText = "";
+            this._filterTextBox.TextChanged += new System.EventHandler(this._filterTextBox_TextChanged);
+            this._filterTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this._filterTextBox_KeyDown);
+            // 
+            // ConnectProfileForm
+            // 
+            this.AcceptButton = this._okButton;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this._cancelButton;
+            this.ClientSize = new System.Drawing.Size(780, 350);
+            this.Controls.Add(this._copyButton);
+            this.Controls.Add(this._hintLabel);
+            this.Controls.Add(this._filterTextBox);
+            this.Controls.Add(this._displaySelectedOnlyCheck);
+            this.Controls.Add(this._selectedProfileCountLabel);
+            this.Controls.Add(this._csvExportButton);
+            this.Controls.Add(this._csvImportButton);
+            this.Controls.Add(this._checkAllOffButton);
+            this.Controls.Add(this._addProfileButton);
+            this.Controls.Add(this._editProfileButton);
+            this.Controls.Add(this._delProfileButton);
+            this.Controls.Add(this._profileCountLabel);
+            this.Controls.Add(this._cancelButton);
+            this.Controls.Add(this._okButton);
+            this.Controls.Add(this._filterLabel);
+            this.Controls.Add(this._profileListView);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "ConnectProfileForm";
+            this.ShowIcon = false;
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "ConnectProfileForm";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.ConnectProfileForm_FormClosing);
+            this.Load += new System.EventHandler(this.ConnectProfileForm_Load);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.ListView _profileListView;
+        private System.Windows.Forms.Label _filterLabel;
+        private System.Windows.Forms.Button _okButton;
+        private System.Windows.Forms.Button _cancelButton;
+        private System.Windows.Forms.ColumnHeader _hostNameColumn;
+        private System.Windows.Forms.ColumnHeader _userNameColumn;
+        private System.Windows.Forms.ColumnHeader _autoLoginColumn;
+        private System.Windows.Forms.ColumnHeader _protocolColumn;
+        private System.Windows.Forms.ColumnHeader _portColumn;
+        private System.Windows.Forms.ColumnHeader _suSwitchColumn;
+        private System.Windows.Forms.ColumnHeader _charCodeColumn;
+        private System.Windows.Forms.ColumnHeader _newLineColumn;
+        private System.Windows.Forms.ColumnHeader _execCommandColumn;
+        private System.Windows.Forms.Button _addProfileButton;
+        private System.Windows.Forms.Button _delProfileButton;
+        private System.Windows.Forms.Button _csvExportButton;
+        private System.Windows.Forms.Button _csvImportButton;
+        private System.Windows.Forms.ColumnHeader _terminalBGColorColumn;
+        private System.Windows.Forms.ColumnHeader _descriptionColumn;
+        private System.Windows.Forms.Label _profileCountLabel;
+        private System.Windows.Forms.Button _editProfileButton;
+        private System.Windows.Forms.Button _checkAllOffButton;
+        private System.Windows.Forms.Timer _filterTimer;
+        private System.Windows.Forms.Label _selectedProfileCountLabel;
+        private System.Windows.Forms.CheckBox _displaySelectedOnlyCheck;
+        private Poderosa.UI.WaterMarkTextBox _filterTextBox;
+        private System.Windows.Forms.SaveFileDialog _saveCSVFileDialog;
+        private System.Windows.Forms.OpenFileDialog _openCSVFileDialog;
+        private System.Windows.Forms.Label _hintLabel;
+        private System.Windows.Forms.Button _copyButton;
+    }
+
+}

--- a/ConnectProfile/ConnectProfileForm.Designer.cs
+++ b/ConnectProfile/ConnectProfileForm.Designer.cs
@@ -46,8 +46,6 @@
             this._protocolColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this._portColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this._suSwitchColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this._charCodeColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this._newLineColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this._execCommandColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this._terminalBGColorColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this._descriptionColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
@@ -82,8 +80,6 @@
             this._protocolColumn,
             this._portColumn,
             this._suSwitchColumn,
-            this._charCodeColumn,
-            this._newLineColumn,
             this._execCommandColumn,
             this._terminalBGColorColumn,
             this._descriptionColumn});
@@ -149,37 +145,22 @@
             // _autoLoginColumn
             // 
             this._autoLoginColumn.Text = "_autoLoginColumn";
-            this._autoLoginColumn.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             this._autoLoginColumn.Width = 103;
             // 
             // _protocolColumn
             // 
             this._protocolColumn.Text = "_protocolColumn";
-            this._protocolColumn.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             this._protocolColumn.Width = 95;
             // 
             // _portColumn
             // 
             this._portColumn.Text = "_portColumn";
-            this._portColumn.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this._portColumn.Width = 74;
             // 
             // _suSwitchColumn
             // 
             this._suSwitchColumn.Text = "_suSwitchColumn";
             this._suSwitchColumn.Width = 100;
-            // 
-            // _charCodeColumn
-            // 
-            this._charCodeColumn.Text = "_charCodeColumn";
-            this._charCodeColumn.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this._charCodeColumn.Width = 102;
-            // 
-            // _newLineColumn
-            // 
-            this._newLineColumn.Text = "_newLineColumn";
-            this._newLineColumn.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this._newLineColumn.Width = 95;
             // 
             // _execCommandColumn
             // 
@@ -408,8 +389,6 @@
         private System.Windows.Forms.ColumnHeader _protocolColumn;
         private System.Windows.Forms.ColumnHeader _portColumn;
         private System.Windows.Forms.ColumnHeader _suSwitchColumn;
-        private System.Windows.Forms.ColumnHeader _charCodeColumn;
-        private System.Windows.Forms.ColumnHeader _newLineColumn;
         private System.Windows.Forms.ColumnHeader _execCommandColumn;
         private System.Windows.Forms.Button _addProfileButton;
         private System.Windows.Forms.Button _delProfileButton;

--- a/ConnectProfile/ConnectProfileForm.cs
+++ b/ConnectProfile/ConnectProfileForm.cs
@@ -1,0 +1,680 @@
+﻿using System;
+using System.Collections;
+using System.IO;
+using System.Windows.Forms;
+
+
+namespace Poderosa.ConnectProfile {
+    /// <summary>
+    /// ConnectProfileメインフォームクラス
+    /// </summary>
+    public partial class ConnectProfileForm : Form {
+        // メンバー変数
+        private Commands _cmd = new Commands();
+        private int _selectCnt = 0;
+        private bool _doubleClickFlg = false;
+        private bool _refreshingFlg = false;
+        private MouseButtons _clickButton;
+        private ListViewItemComparer _listViewItemSorter;
+        private static bool _connectCancelFlg;
+
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        public ConnectProfileForm() {
+            InitializeComponent();
+            InitializeComponentValue();
+
+            // 設定ファイル読み込み
+            if (ConnectProfilePlugin.Instance.ConnectProfileOptionSupplier.PreferenceLoaded != true) {
+                ConnectProfilePlugin.Instance.ConnectProfileOptionSupplier.LoadFromPreference();
+            }
+            RefreshAllProfiles();
+        }
+
+        /// <summary>
+        /// オブジェクト各値設定
+        /// </summary>
+        private void InitializeComponentValue() {
+            // テキスト
+            this.Text = ConnectProfilePlugin.Strings.GetString("Caption.ConnectProfile");
+            this._addProfileButton.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._addProfileButton");
+            this._autoLoginColumn.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._autoLoginColumn");
+            this._cancelButton.Text = ConnectProfilePlugin.Strings.GetString("Form.Common._cancelButton");
+            this._charCodeColumn.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._charCodeColumn");
+            this._checkAllOffButton.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._checkAllOffButton");
+            this._copyButton.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._copyButton");
+            this._csvExportButton.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._csvExportButton");
+            this._csvImportButton.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._csvImportButton");
+            this._delProfileButton.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._delProfileButton");
+            this._descriptionColumn.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._descriptionColumn");
+            this._displaySelectedOnlyCheck.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._displaySelectedOnlyCheck");
+            this._editProfileButton.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._editProfileButton");
+            this._execCommandColumn.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._execCommandColumn");
+            this._filterLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._filterLabel");
+            this._filterTextBox.WaterMarkText = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._filterTextBox");
+            this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._hintLabel");
+            this._hostNameColumn.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._hostNameColumn");
+            this._newLineColumn.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._newLineColumn");
+            this._okButton.Text = ConnectProfilePlugin.Strings.GetString("Form.Common._okButton");
+            this._openCSVFileDialog.Filter = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._openCSVFileDialog.Filter");
+            this._openCSVFileDialog.Title = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._openCSVFileDialog.Caption");
+            this._portColumn.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._portColumn");
+            this._profileCountLabel.Text = String.Format(ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._profileCountLabel"), 0);
+            this._protocolColumn.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._protocolColumn");
+            this._saveCSVFileDialog.Filter = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._saveCSVFileDialog.Filter");
+            this._saveCSVFileDialog.Title = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._saveCSVFileDialog.Caption");
+            this._selectedProfileCountLabel.Text = String.Format(ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._selectedProfileCountLabel"), 0);
+            this._suSwitchColumn.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._suSwitchColumn");
+            this._terminalBGColorColumn.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._terminalBGColorColumn");
+            this._userNameColumn.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._userNameColumn");
+
+            // ファイル保存/開くダイアログ設定
+            this._saveCSVFileDialog.DefaultExt = "csv";
+            this._saveCSVFileDialog.AddExtension = true;
+            this._openCSVFileDialog.DefaultExt = "csv";
+            this._openCSVFileDialog.CheckFileExists = true;
+            this._openCSVFileDialog.Multiselect = false;
+
+            // プロファイルリストカラム幅
+            this._hostNameColumn.Width = -2;
+            this._userNameColumn.Width = -2;
+            this._autoLoginColumn.Width = -2;
+            this._protocolColumn.Width = -2;
+            this._portColumn.Width = -2;
+            this._suSwitchColumn.Width = -2;
+            this._charCodeColumn.Width = -2;
+            this._newLineColumn.Width = -2;
+            this._execCommandColumn.Width = -2;
+            this._terminalBGColorColumn.Width = -2;
+            this._descriptionColumn.Width = -2;
+
+            // プロファイルリストソートイベント作成/設定
+            _listViewItemSorter = new ListViewItemComparer();
+            _listViewItemSorter.ColumnModes = new ListViewItemComparer.ComparerMode[] {
+                ListViewItemComparer.ComparerMode.String,
+                ListViewItemComparer.ComparerMode.String,
+                ListViewItemComparer.ComparerMode.String,
+                ListViewItemComparer.ComparerMode.String,
+                ListViewItemComparer.ComparerMode.Integer,
+                ListViewItemComparer.ComparerMode.String,
+                ListViewItemComparer.ComparerMode.String,
+                ListViewItemComparer.ComparerMode.String,
+                ListViewItemComparer.ComparerMode.String,
+                ListViewItemComparer.ComparerMode.String,
+                ListViewItemComparer.ComparerMode.String,
+            };
+            _profileListView.ListViewItemSorter = _listViewItemSorter;
+        }
+
+        /// <summary>
+        /// プロファイルリスト更新
+        /// </summary>
+        private void RefreshAllProfiles() {
+            string str = "";
+            _refreshingFlg = true;
+            _profileListView.BeginUpdate();
+            _profileListView.Items.Clear();
+
+            // 各データ代入
+            foreach (ConnectProfileStruct prof in ConnectProfilePlugin.Profiles) {
+                str = string.Format("{0} {1} {2} {3} {4} {5} {6} {7} {8}", prof.HostName, prof.UserName, prof.Protocol.ToString(), prof.Port.ToString(), prof.SUUserName, prof.CharCode.ToString(), prof.NewLine, prof.ExecCommand, prof.Description);
+                // フィルタ
+                if (IsVisibleItem(str) == true) {
+                    // チェックONのみ表示
+                    if (_displaySelectedOnlyCheck.Checked == true) {
+                        if (prof.Check != true) continue;
+                    }
+
+                    // リストオブジェクト作成
+                    ListViewItem li = new ListViewItem();
+                    li.UseItemStyleForSubItems = false; // サブアイテム書式設定用
+
+                    // データ代入
+                    li.Text = prof.HostName;
+                    li.SubItems.Add(prof.UserName);
+                    li.SubItems.Add((prof.AutoLogin == true) ? ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile_profileListView.Yes") : ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile_profileListView.No"));
+                    li.SubItems.Add(prof.Protocol.ToString());
+                    li.SubItems.Add(prof.Port.ToString());
+                    li.SubItems.Add((prof.SUUserName != "") ? prof.SUUserName : "");
+                    li.SubItems.Add(prof.CharCode.ToString());
+                    li.SubItems.Add(prof.NewLine.ToString());
+                    li.SubItems.Add((prof.ExecCommand != "") ? prof.ExecCommand : "");
+                    li.SubItems.Add(""); // 背景色
+                    li.SubItems.Add((prof.Description != "") ? prof.Description : "");
+
+                    // 項目/背景色設定
+                    li.ForeColor = prof.ProfileItemColor;
+                    for (int i = 0; i < li.SubItems.Count; i++) {
+                        li.SubItems[i].ForeColor = prof.ProfileItemColor;
+                        if (i == 9) li.SubItems[i].BackColor = prof.TerminalBGColor;
+                    }
+
+                    // チェック状態復元
+                    li.Checked = prof.Check;
+
+                    // タグ追加
+                    li.Tag = prof;
+
+                    // アイテム追加
+                    _profileListView.Items.Add(li);
+                }
+            }
+            _profileListView.EndUpdate();
+            _profileListView.SelectedItems.Clear();
+
+            // プロファイル数ラベル更新
+            _profileCountLabel.Text = String.Format(ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._profileCountLabel"), ConnectProfilePlugin.Profiles.Count);
+            _refreshingFlg = false;
+        }
+
+        /// <summary>
+        /// プロファイルリスト選択数更新
+        /// </summary>
+        private void RefreshSelectCount() {
+            _selectCnt = 0;
+            foreach (ConnectProfileStruct prof in ConnectProfilePlugin.Profiles) {
+                if (prof.Check == true) _selectCnt++;
+            }
+            _selectedProfileCountLabel.Text = String.Format(ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._selectedProfileCountLabel"), _selectCnt);
+        }
+
+        /// <summary>
+        /// フィルター対象抽出(大小文字区別なし, 空白区切りでAND条件)
+        /// </summary>
+        private bool IsVisibleItem(string targetstr) {
+            string[] keys = _filterTextBox.Text.Split(' ');
+            int index = 0;
+
+            foreach (string key in keys) {
+                index = targetstr.IndexOf(key, StringComparison.OrdinalIgnoreCase);
+                if (index < 0) break;
+            }
+            return (index >= 0) ? true : false;
+        }
+
+        /// <summary>
+        /// 選択中のプロファイルリストを取得
+        /// </summary>
+        private ConnectProfileStruct GetSelectedProfile() {
+            return (_profileListView.SelectedItems.Count == 0) ? null : (ConnectProfileStruct)_profileListView.SelectedItems[0].Tag;
+        }
+
+        /// <summary>
+        /// 選択済みプロファイルリストのホスト名を取得
+        /// </summary>
+        private string GetSelectedProfileHostNames() {
+            string str = "";
+            foreach (ConnectProfileStruct prof in ConnectProfilePlugin.Profiles) {
+                if (prof.Check == true) str += prof.HostName + ", ";
+            }
+            return str;
+        }
+
+        /// <summary>
+        /// プロファイル接続
+        /// </summary>
+        private void Connect(ConnectProfileStruct prof) {
+            if (prof != null) {
+                _cmd.ConnectProfile(prof);
+            }
+        }
+
+        /// <summary>
+        /// プロファイル追加
+        /// </summary>
+        private void AddProfile() {
+            _cmd.NewProfileCommand(ConnectProfilePlugin.Profiles);
+            RefreshAllProfiles();
+        }
+
+        /// <summary>
+        /// プロファイル編集
+        /// </summary>
+        private void EditProfile() {
+            ConnectProfileStruct prof = GetSelectedProfile();
+            if (prof != null) {
+                _cmd.EditProfileCommand(ConnectProfilePlugin.Profiles, prof);
+                RefreshAllProfiles();
+            }
+        }
+
+        /// <summary>
+        /// プロファイルコピー&編集
+        /// </summary>
+        private void CopyEditProfile() {
+            ConnectProfileStruct prof = GetSelectedProfile();
+            if (prof != null) {
+                _cmd.CopyEditProfileCommand(ConnectProfilePlugin.Profiles, prof);
+                RefreshAllProfiles();
+            }
+        }
+
+        /// <summary>
+        /// プロファイル削除
+        /// </summary>
+        private void DeleteProfile() {
+            ConnectProfileStruct prof = GetSelectedProfile();
+            if (prof != null) {
+                _cmd.DeleteProfileCommand(ConnectProfilePlugin.Profiles, prof);
+                RefreshAllProfiles();
+                RefreshSelectCount();
+            }
+        }
+
+        /// <summary>
+        /// オブジェクト有効/無効化
+        /// </summary>
+        private void EnableControl(bool val) {
+            _okButton.Enabled = val;
+            _filterTextBox.Enabled = val;
+            _checkAllOffButton.Enabled = val;
+            _addProfileButton.Enabled = val;
+            _editProfileButton.Enabled = val;
+            _delProfileButton.Enabled = val;
+            _copyButton.Enabled = val;
+            _csvExportButton.Enabled = val;
+            _csvImportButton.Enabled = val;
+            _displaySelectedOnlyCheck.Enabled = val;
+            _profileListView.Enabled = val;
+        }
+
+        /// <summary>
+        /// フィルターテキスト変更イベント
+        /// </summary>
+        private void _filterTextBox_TextChanged(object sender, System.EventArgs e) {
+            _filterTimer.Stop();
+            _filterTimer.Start();
+        }
+
+        /// <summary>
+        /// フィルターテキストキー押下イベント
+        /// </summary>
+        private void _filterTextBox_KeyDown(object sender, KeyEventArgs e) {
+            // 上下キー押下時はリストビューにフォーカス
+            if ((e.KeyCode == Keys.Up) || (e.KeyCode == Keys.Down)) _profileListView.Focus();
+        }
+
+        /// <summary>
+        /// OKボタンイベント
+        /// </summary>
+        private void _okButton_Click(object sender, EventArgs e) {
+            ArrayList hostlist = new ArrayList();
+            this.DialogResult = DialogResult.None;
+            _connectCancelFlg = false;
+            EnableControl(false);
+
+            if ((_selectCnt == 0) && (_profileListView.Items.Count == 1)) {
+                // 選択数0 & リスト1行のみ
+                _profileListView.Items[0].Selected = true;
+                Connect(GetSelectedProfile());
+                this.DialogResult = DialogResult.OK;
+            } else if ((_selectCnt == 0) && (_profileListView.SelectedItems.Count == 1)) {
+                // 選択数0 & リスト1行選択
+                Connect(GetSelectedProfile());
+                this.DialogResult = DialogResult.OK;
+            } else if (_selectCnt > 0) {
+                // 選択数1以上(複数接続)
+                foreach (ConnectProfileStruct prof in ConnectProfilePlugin.Profiles) {
+                    if (prof.Check == true) hostlist.Add(prof.HostName);
+                }
+
+                // 接続確認
+                if (ConnectProfilePlugin.AskUserYesNoInvoke(String.Format(ConnectProfilePlugin.Strings.GetString("Message.ConnectProfile.ConnectConfirm"), _selectCnt, String.Join(", ", (string[])hostlist.ToArray(typeof(string)))), MessageBoxIcon.Information) == DialogResult.Yes) {
+                    // 接続
+                    foreach (ConnectProfileStruct prof in ConnectProfilePlugin.Profiles) {
+                        if (_connectCancelFlg != true) {
+                            if (prof.Check == true) Connect(prof);
+                        } else {
+                            ConnectProfilePlugin.MessageBoxInvoke(ConnectProfilePlugin.Strings.GetString("Message.ConnectProfile.ConnectCancel"), MessageBoxIcon.Warning);
+                            this.DialogResult = DialogResult.None;
+                            EnableControl(true);
+                            _okButton.Focus();
+                            return;
+                        }
+                    }
+                    this.DialogResult = DialogResult.OK;
+                } else {
+                    // キャンセル
+                    EnableControl(true);
+                    _okButton.Focus();
+                }
+            } else {
+                // リスト未選択
+                ConnectProfilePlugin.AskUserYesNoInvoke(ConnectProfilePlugin.Strings.GetString("Message.ConnectProfile.ProfileNotSelected"), MessageBoxIcon.Warning);
+                EnableControl(true);
+                _okButton.Focus();
+            }
+        }
+
+        /// <summary>
+        /// キャンセルボタンイベント
+        /// </summary>
+        private void _cancelButton_Click(object sender, EventArgs e) {
+            _connectCancelFlg = true; // フォーム用
+            _cmd.ConnectCancel(); // スレッド用
+        }
+
+        /// <summary>
+        /// チェック全解除ボタンイベント
+        /// </summary>
+        private void _checkAllOffButton_Click(object sender, EventArgs e) {
+            foreach (ConnectProfileStruct prof in ConnectProfilePlugin.Profiles) {
+                prof.Check = false;
+            }
+            RefreshAllProfiles();
+            RefreshSelectCount();
+        }
+
+        /// <summary>
+        /// 追加ボタンイベント
+        /// </summary>
+        private void _addProfileButton_Click(object sender, EventArgs e) {
+            AddProfile();
+        }
+
+        /// <summary>
+        /// 編集ボタンイベント
+        /// </summary>
+        private void _editProfileButton_Click(object sender, EventArgs e) {
+            EditProfile();
+        }
+
+        /// <summary>
+        /// 削除ボタンイベント
+        /// </summary>
+        private void _delProfileButton_Click(object sender, EventArgs e) {
+            DeleteProfile();
+        }
+
+        /// <summary>
+        /// コピーボタンイベント
+        /// </summary>
+        private void _copyButton_Click(object sender, EventArgs e) {
+            CopyEditProfile();
+        }
+
+        /// <summary>
+        /// CSVエクスポートクリックイベント
+        /// </summary>
+        private void _csvExportButton_Click(object sender, System.EventArgs e) {
+            StreamWriter sw = null;
+            bool delPWFlg = false;
+
+            if (_saveCSVFileDialog.ShowDialog() == DialogResult.OK) {
+                // パスワード出力/削除確認
+                if (ConnectProfilePlugin.AskUserYesNoInvoke(ConnectProfilePlugin.Strings.GetString("Message.ConnectProfile.CSVExportDetetePasssword"), MessageBoxIcon.Question) == DialogResult.Yes) {
+                    delPWFlg = true;
+                }
+
+                // CSVファイル出力
+                try {
+                    sw = new System.IO.StreamWriter(_saveCSVFileDialog.FileName, false, System.Text.Encoding.UTF8);
+                    sw.WriteLine(_cmd.CSVHeader);
+                    foreach (ConnectProfileStruct prof in ConnectProfilePlugin.Profiles) {
+                        sw.WriteLine(_cmd.ConvertCSV(prof, delPWFlg));
+                    }
+                    ConnectProfilePlugin.MessageBoxInvoke(ConnectProfilePlugin.Strings.GetString("Message.ConnectProfile.CSVExportComplete"), MessageBoxIcon.Information);
+                } catch (Exception ex) {
+                    ConnectProfilePlugin.MessageBoxInvoke(ex.Message, MessageBoxIcon.Error);
+                } finally {
+                    if (sw != null) sw.Close();
+                }
+            }
+        }
+
+        /// <summary>
+        /// CSVインポートクリックイベント
+        /// </summary>
+        private void _csvImportButton_Click(object sender, System.EventArgs e) {
+            ConnectProfileList profList = new ConnectProfileList();
+            ConnectProfileStruct prof = new ConnectProfileStruct();
+            StreamReader sr = null;
+            bool appendFlg = false;
+            int lineCnt = 1;
+
+            if (_openCSVFileDialog.ShowDialog() == DialogResult.OK) {
+                // 追加/削除確認
+                if (ConnectProfilePlugin.AskUserYesNoInvoke(ConnectProfilePlugin.Strings.GetString("Message.ConnectProfile.CSVImportAppendProfileList"), MessageBoxIcon.Question) == DialogResult.Yes) {
+                    appendFlg = true;
+                }
+
+                // 実行確認
+                if (ConnectProfilePlugin.AskUserYesNoInvoke(ConnectProfilePlugin.Strings.GetString("Message.ConnectProfile.CSVImportConfirm"), MessageBoxIcon.Question) == DialogResult.Yes) {
+                    try {
+                        sr = new System.IO.StreamReader(_openCSVFileDialog.FileName, System.Text.Encoding.UTF8);
+                        while (!sr.EndOfStream) {
+                            string line = sr.ReadLine();
+
+                            // 各種チェック
+                            if (lineCnt == 1) {
+                                // ヘッダーチェック(1行目固定)
+                                if (_cmd.CheckCSVHeader(line) != true) {
+                                    ConnectProfilePlugin.MessageBoxInvoke(string.Format(ConnectProfilePlugin.Strings.GetString("Message.ConnectProfile.CSVImportInvalidHeader"), lineCnt.ToString()), MessageBoxIcon.Error);
+                                    return;
+                                }
+                            } else if ((line == "") || (line.IndexOf("#") == 0)) {
+                                // 空白行/行頭シャープの行はスキップ
+                                lineCnt++;
+                                continue;
+                            } else {
+                                // フィールド数チェック
+                                if (_cmd.CheckCSVFieldCount(line) != true) {
+                                    ConnectProfilePlugin.MessageBoxInvoke(string.Format(ConnectProfilePlugin.Strings.GetString("Message.ConnectProfile.CSVImportInvalidFieldCount"), lineCnt.ToString()), MessageBoxIcon.Error);
+                                    return;
+                                }
+
+                                // 各項目チェック
+                                prof = _cmd.CheckCSVData(line);
+                                if (prof == null) {
+                                    ConnectProfilePlugin.MessageBoxInvoke(string.Format(ConnectProfilePlugin.Strings.GetString("Message.ConnectProfile.CSVImportFailed"), lineCnt.ToString()), MessageBoxIcon.Error);
+                                    return;
+                                }
+
+                                // プロファイル追加
+                                if (appendFlg == true) _cmd.AddProfileCommand(ConnectProfilePlugin.Profiles, prof);
+                                else _cmd.AddProfileCommand(profList, prof);
+                            }
+                            lineCnt++;
+                        }
+                        // プロファイルリスト全置換
+                        if (appendFlg == false) _cmd.ReplaceAllProfileCommand(ConnectProfilePlugin.Profiles, profList);
+
+                        RefreshAllProfiles();
+                        RefreshSelectCount();
+                        ConnectProfilePlugin.MessageBoxInvoke(ConnectProfilePlugin.Strings.GetString("Message.ConnectProfile.CSVImportComplete"), MessageBoxIcon.Information);
+                    } catch (Exception ex) {
+                        ConnectProfilePlugin.MessageBoxInvoke(ex.Message, MessageBoxIcon.Error);
+                    } finally {
+                        if (sr != null) sr.Close();
+                    }
+                } else {
+                    // キャンセル
+                    ConnectProfilePlugin.MessageBoxInvoke(ConnectProfilePlugin.Strings.GetString("Message.ConnectProfile.CSVImportCancel"), MessageBoxIcon.Warning);
+                }
+            }
+        }
+
+        /// <summary>
+        /// 選択されているプロファイルのみ表示チェックボックスクリックイベント
+        /// </summary>
+        private void _displaySelectedOnlyCheck_CheckedChanged(object sender, EventArgs e) {
+            if (_selectCnt == 0) _profileListView.SelectedItems.Clear();
+            RefreshAllProfiles();
+        }
+
+        /// <summary>
+        /// プロファイルリストカラムクリックイベント
+        /// </summary>
+        private void _profileListView_ColumnClick(object sender, System.Windows.Forms.ColumnClickEventArgs e) {
+            _listViewItemSorter.Column = e.Column;
+            _profileListView.Sort();
+        }
+
+        /// <summary>
+        /// プロファイルリストマウス押下イベント
+        /// </summary>
+        private void _profileListView_MouseDown(object sender, MouseEventArgs e) {
+            // 押下ボタン/ダブルクリックチェック
+            _doubleClickFlg = (2 <= e.Clicks) ? true : false;
+            _clickButton = e.Button;
+
+            // 左ダブルクリック=接続, 中ダブルクリック=追加, 右ダブルクリック=編集
+            if ((_doubleClickFlg == true) && (_clickButton == MouseButtons.Left)) {
+                if (_selectCnt == 0) Connect(GetSelectedProfile());
+            } else if ((_doubleClickFlg == true) && (_clickButton == MouseButtons.Middle)) {
+                AddProfile();
+            } else if ((_doubleClickFlg == true) && (_clickButton == MouseButtons.Right)) {
+                EditProfile();
+            }
+        }
+
+        /// <summary>
+        /// プロファイルリストチェックステータス変更前イベント
+        /// </summary>
+        private void _profileListView_ItemCheck(object sender, ItemCheckEventArgs e) {
+            // 何も選択されていない状態でダブルクリックした場合はチェックステータスを変更しない(左ダブルクリック接続用)
+            if ((_selectCnt == 0) && (_doubleClickFlg == true)) e.NewValue = e.CurrentValue;
+        }
+
+        /// <summary>
+        /// プロファイルリストチェックステータス変更後イベント
+        /// </summary>
+        private void _profileListView_ItemChecked(object sender, ItemCheckedEventArgs e) {
+            // リスト更新実行中はスキップ(RefreshAllProfiles実行中にも度々イベントが発生してしまうため)
+            if (_refreshingFlg != true) {
+                e.Item.Selected = true; // チェックボックスクリック時は選択状態にならないため明示的に選択状態にする
+                ConnectProfileStruct prof = GetSelectedProfile();
+                if (prof != null) {
+                    prof.Check = e.Item.Checked;
+                    RefreshSelectCount();
+                }
+            }
+        }
+
+        /// <summary>
+        /// フィルタータイマーイベント
+        /// </summary>
+        private void _filterTime_Tick(object sender, EventArgs e) {
+            _filterTimer.Stop();
+            RefreshAllProfiles();
+        }
+
+        /// <summary>
+        /// フォームロードイベント
+        /// </summary>
+        private void ConnectProfileForm_Load(object sender, EventArgs e) {
+            // フォーム表示時はリスト未選択状態
+            _profileListView.SelectedItems.Clear();
+        }
+
+        /// <summary>
+        /// フォームクローズイベント
+        /// </summary>
+        private void ConnectProfileForm_FormClosing(object sender, FormClosingEventArgs e) {
+            // 全プロファイルのチェック状態をOFFに設定
+            foreach (ConnectProfileStruct prof in ConnectProfilePlugin.Profiles) {
+                prof.Check = false;
+            }
+        }
+    }
+
+
+
+
+    /// <summary>
+    /// ListViewカラムソートクラス
+    /// </summary>
+    public class ListViewItemComparer : IComparer {
+        // メンバー変数
+        public enum ComparerMode { String, Integer, DateTime };
+        private int _column;
+        private SortOrder _order;
+        private ComparerMode _mode;
+        private ComparerMode[] _columnModes;
+
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        /// <param name="col">ソート列番号</param>
+        /// <param name="ord">ソートオーダー</param>
+        /// <param name="cmod">ソート方法</param>
+        public ListViewItemComparer(int col, SortOrder ord, ComparerMode cmod) {
+            _column = col;
+            _order = ord;
+            _mode = cmod;
+        }
+        public ListViewItemComparer() {
+            _column = 0;
+            _order = SortOrder.Ascending;
+            _mode = ComparerMode.String;
+        }
+
+        /// <summary>
+        /// ソート
+        /// </summary>
+        /// <param name="x">ListViewItem</param>
+        /// <param name="y">ListViewItem</param>
+        public int Compare(object x, object y) {
+            int result = 0;
+            ListViewItem itemx = (ListViewItem)x;
+            ListViewItem itemy = (ListViewItem)y;
+
+            if (_order == SortOrder.None) return 0;
+
+            // ソート方法決定
+            if (_columnModes != null && _columnModes.Length > _column) _mode = _columnModes[_column];
+
+            // ソート方法別にxとyを比較
+            switch (_mode) {
+                case ComparerMode.String:   // 文字列
+                    result = string.Compare(itemx.SubItems[_column].Text, itemy.SubItems[_column].Text);
+                    break;
+                case ComparerMode.Integer:  // 数値
+                    result = int.Parse(itemx.SubItems[_column].Text).CompareTo(int.Parse(itemy.SubItems[_column].Text));
+                    break;
+                case ComparerMode.DateTime: // 日付
+                    result = DateTime.Compare(DateTime.Parse(itemx.SubItems[_column].Text), DateTime.Parse(itemy.SubItems[_column].Text));
+                    break;
+            }
+
+            // 降順時は結果を+-逆にする
+            return (_order == SortOrder.Descending) ? -result : result;
+        }
+
+        /// <summary>
+        /// ソート列番号
+        /// </summary>
+        public int Column {
+            set {
+                // 同一列の時は昇順降順をスイッチ
+                if (_column == value) {
+                    if (_order == SortOrder.Ascending) _order = SortOrder.Descending;
+                    else if (_order == SortOrder.Descending) _order = SortOrder.Ascending;
+                }
+                _column = value;
+            }
+            get { return _column; }
+        }
+        /// <summary>
+        /// ソートオーダー
+        /// </summary>
+        public SortOrder Order {
+            set { _order = value; }
+            get { return _order; }
+        }
+        /// <summary>
+        /// ソート方法
+        /// </summary>
+        public ComparerMode Mode {
+            set { _mode = value; }
+            get { return _mode; }
+        }
+        /// <summary>
+        /// 列毎のソート方法
+        /// </summary>
+        public ComparerMode[] ColumnModes {
+            set { _columnModes = value; }
+        }
+    }
+}

--- a/ConnectProfile/ConnectProfileForm.cs
+++ b/ConnectProfile/ConnectProfileForm.cs
@@ -41,7 +41,6 @@ namespace Poderosa.ConnectProfile {
             this._addProfileButton.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._addProfileButton");
             this._autoLoginColumn.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._autoLoginColumn");
             this._cancelButton.Text = ConnectProfilePlugin.Strings.GetString("Form.Common._cancelButton");
-            this._charCodeColumn.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._charCodeColumn");
             this._checkAllOffButton.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._checkAllOffButton");
             this._copyButton.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._copyButton");
             this._csvExportButton.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._csvExportButton");
@@ -55,7 +54,6 @@ namespace Poderosa.ConnectProfile {
             this._filterTextBox.WaterMarkText = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._filterTextBox");
             this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._hintLabel");
             this._hostNameColumn.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._hostNameColumn");
-            this._newLineColumn.Text = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._newLineColumn");
             this._okButton.Text = ConnectProfilePlugin.Strings.GetString("Form.Common._okButton");
             this._openCSVFileDialog.Filter = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._openCSVFileDialog.Filter");
             this._openCSVFileDialog.Title = ConnectProfilePlugin.Strings.GetString("Form.ConnectProfile._openCSVFileDialog.Caption");
@@ -83,9 +81,7 @@ namespace Poderosa.ConnectProfile {
             this._protocolColumn.Width = -2;
             this._portColumn.Width = -2;
             this._suSwitchColumn.Width = -2;
-            this._charCodeColumn.Width = -2;
-            this._newLineColumn.Width = -2;
-            this._execCommandColumn.Width = -2;
+            this._execCommandColumn.Width = -1;
             this._terminalBGColorColumn.Width = -2;
             this._descriptionColumn.Width = -2;
 
@@ -118,7 +114,7 @@ namespace Poderosa.ConnectProfile {
 
             // 各データ代入
             foreach (ConnectProfileStruct prof in ConnectProfilePlugin.Profiles) {
-                str = string.Format("{0} {1} {2} {3} {4} {5} {6} {7} {8}", prof.HostName, prof.UserName, prof.Protocol.ToString(), prof.Port.ToString(), prof.SUUserName, prof.CharCode.ToString(), prof.NewLine, prof.ExecCommand, prof.Description);
+                str = string.Format("{0} {1} {2} {3} {4} {5} {6}", prof.HostName, prof.UserName, prof.Protocol.ToString(), prof.Port.ToString(), prof.SUUserName, prof.ExecCommand, prof.Description);
                 // フィルタ
                 if (IsVisibleItem(str) == true) {
                     // チェックONのみ表示
@@ -137,8 +133,6 @@ namespace Poderosa.ConnectProfile {
                     li.SubItems.Add(prof.Protocol.ToString());
                     li.SubItems.Add(prof.Port.ToString());
                     li.SubItems.Add((prof.SUUserName != "") ? prof.SUUserName : "");
-                    li.SubItems.Add(prof.CharCode.ToString());
-                    li.SubItems.Add(prof.NewLine.ToString());
                     li.SubItems.Add((prof.ExecCommand != "") ? prof.ExecCommand : "");
                     li.SubItems.Add(""); // 背景色
                     li.SubItems.Add((prof.Description != "") ? prof.Description : "");
@@ -147,7 +141,7 @@ namespace Poderosa.ConnectProfile {
                     li.ForeColor = prof.ProfileItemColor;
                     for (int i = 0; i < li.SubItems.Count; i++) {
                         li.SubItems[i].ForeColor = prof.ProfileItemColor;
-                        if (i == 9) li.SubItems[i].BackColor = prof.TerminalBGColor;
+                        if (i == 7) li.SubItems[i].BackColor = prof.TerminalBGColor;
                     }
 
                     // チェック状態復元
@@ -216,7 +210,10 @@ namespace Poderosa.ConnectProfile {
         /// </summary>
         private void Connect(ConnectProfileStruct prof) {
             if (prof != null) {
+                // 接続中はダイアログタイトルにホスト名を表示
+                this.Text = string.Format(ConnectProfilePlugin.Strings.GetString("Caption.ConnectProfile.Connecting"), prof.HostName);
                 _cmd.ConnectProfile(prof);
+                this.Text = ConnectProfilePlugin.Strings.GetString("Caption.ConnectProfile");
             }
         }
 
@@ -326,6 +323,7 @@ namespace Poderosa.ConnectProfile {
                         if (_connectCancelFlg != true) {
                             if (prof.Check == true) Connect(prof);
                         } else {
+                            // キャンセルボタン押下
                             ConnectProfilePlugin.MessageBoxInvoke(ConnectProfilePlugin.Strings.GetString("Message.ConnectProfile.ConnectCancel"), MessageBoxIcon.Warning);
                             this.DialogResult = DialogResult.None;
                             EnableControl(true);
@@ -521,7 +519,11 @@ namespace Poderosa.ConnectProfile {
 
             // 左ダブルクリック=接続, 中ダブルクリック=追加, 右ダブルクリック=編集
             if ((_doubleClickFlg == true) && (_clickButton == MouseButtons.Left)) {
-                if (_selectCnt == 0) Connect(GetSelectedProfile());
+                if (_selectCnt == 0) {
+                    EnableControl(false);
+                    Connect(GetSelectedProfile());
+                    EnableControl(true);
+                }
             } else if ((_doubleClickFlg == true) && (_clickButton == MouseButtons.Middle)) {
                 AddProfile();
             } else if ((_doubleClickFlg == true) && (_clickButton == MouseButtons.Right)) {

--- a/ConnectProfile/ConnectProfileForm.resx
+++ b/ConnectProfile/ConnectProfileForm.resx
@@ -1,0 +1,132 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="_filterTimer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="_saveCSVFileDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>139, 17</value>
+  </metadata>
+  <metadata name="_openCSVFileDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>308, 17</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>41</value>
+  </metadata>
+</root>

--- a/ConnectProfile/ConnectProfileList.cs
+++ b/ConnectProfile/ConnectProfileList.cs
@@ -1,0 +1,318 @@
+﻿using System.Collections;
+using System.Drawing;
+
+using Poderosa.ConnectionParam;
+
+
+namespace Poderosa.ConnectProfile {
+    /// <summary>
+    /// プロファイルリスト管理クラス
+    /// </summary>
+    internal class ConnectProfileList : IEnumerable {
+        // メンバー変数
+        private ArrayList _data;
+
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        public ConnectProfileList() {
+            _data = new ArrayList();
+        }
+
+        /// <summary>
+        /// GetEnumerator
+        /// </summary>
+        public IEnumerator GetEnumerator() {
+            return _data.GetEnumerator();
+        }
+
+        /// <summary>
+        /// プロファイルを追加
+        /// </summary>
+        /// <param name="p">プロファイル</param>
+        public void AddProfile(ConnectProfileStruct p) {
+            _data.Add(p);
+        }
+
+        /// <summary>
+        /// プロファイルを削除
+        /// </summary>
+        /// <param name="p">プロファイル</param>
+        public void DeleteProfile(ConnectProfileStruct p) {
+            _data.Remove(p);
+        }
+
+        /// <summary>
+        /// プロファイルを置換
+        /// </summary>
+        /// <param name="p1">置換前プロファイル</param>
+        /// <param name="p2">置換後プロファイル</param>
+        public void ReplaceProfile(ConnectProfileStruct p1, ConnectProfileStruct p2) {
+            _data[_data.IndexOf(p1)] = p2;
+        }
+
+        /// <summary>
+        /// 全プロファイルリストを削除
+        /// </summary>
+        public void DeleteAllProfile() {
+            _data.Clear();
+        }
+
+        /// <summary>
+        /// 全プロファイルリストを置換
+        /// </summary>
+        /// <param name="pl">置換後プロファイルリスト</param>
+        public void ReplaceAllProfile(ConnectProfileList pl) {
+            DeleteAllProfile();
+            _data = pl._data;
+        }
+
+        /// <summary>
+        /// プロファイル定義数
+        /// </summary>
+        public int Count {
+            get { return _data.Count; }
+        }
+    }
+
+
+
+
+    /// <summary>
+    /// プロファイル情報構成クラス
+    /// </summary>
+    public class ConnectProfileStruct {
+        // メンバー変数
+        public const int DEFAULT_TELNET_PORT = 23;
+        public const int DEFAULT_SSH_PORT = 22;
+        public const int DEFAULT_CMD_SEND_INTERVAL = 200;
+        public const int DEFAULT_PROMPT_RECV_TIMEOUT = 5000;
+        public const string FMT_CSV = "{00},{01},{02},{03},{04},{05},{06},{07},{08},{09},{10},{11},{12},{13},{14},{15},{16},{17},{18},{19},{20},{21},{22},{23}";
+        public const int CSV_FIELD_CNT = 24;
+        private string _hostName;           // ホスト名
+        private ConnectionMethod _protocol; // プロトコル
+        private int _port;                  // ポート
+        private AuthType _authType;         // SSH認証方法
+        private string _keyFile;            // 秘密鍵ファイル
+        private string _userName;           // ユーザ名
+        private string _password;           // パスワード
+        private bool _autoLogin;            // 自動ログイン
+        private string _loginPrompt;        // ログインプロンプト
+        private string _passwordPrompt;     // パスワードプロンプト
+        private string _execCommand;        // 実行コマンド
+        private string _suUserName;         // SUユーザ名
+        private string _suPassword;         // SUパスワード
+        private string _suType;             // SUコマンド種類
+        private EncodingType _charCode;     // 文字コード
+        private NewLine _newLine;           // 改行コード
+        private bool _telnetNewLine;        // TelnetNewLine
+        private TerminalType _terminalType; // ターミナル種類
+        private Color _terminalFontColor;   // フォント色
+        private Color _terminalBGColor;     // 背景色
+        private int _commandSendInterval;   // コマンド発行間隔
+        private int _promptRecvTimeout;     // プロンプト受信タイムアウト
+        private Color _profileItemColor;    // プロファイル項目色
+        private string _description;        // 説明
+        private bool _checkState = false;   // リストチェック状態(ListView用)
+
+        /// <summary>
+        /// ホスト名
+        /// </summary>
+        public string HostName {
+            get { return _hostName; }
+            set { _hostName = value; }
+        }
+
+        /// <summary>
+        /// プロトコル
+        /// </summary>
+        public ConnectionMethod Protocol {
+            get { return _protocol; }
+            set { _protocol = value; }
+        }
+
+        /// <summary>
+        /// ポート
+        /// </summary>
+        public int Port {
+            get { return _port; }
+            set { _port = value; }
+        }
+
+        /// <summary>
+        /// SSH認証方法
+        /// </summary>
+        public AuthType AuthType {
+            get { return _authType; }
+            set { _authType = value; }
+        }
+
+        /// <summary>
+        /// 秘密鍵ファイル
+        /// </summary>
+        public string KeyFile {
+            get { return _keyFile; }
+            set { _keyFile = value; }
+        }
+
+        /// <summary>
+        /// ユーザ名
+        /// </summary>
+        public string UserName {
+            get { return _userName; }
+            set { _userName = value; }
+        }
+
+        /// <summary>
+        /// パスワード
+        /// </summary>
+        public string Password {
+            get { return _password; }
+            set { _password = value; }
+        }
+
+        /// <summary>
+        /// 自動ログイン
+        /// </summary>
+        public bool AutoLogin {
+            get { return _autoLogin; }
+            set { _autoLogin = value; }
+        }
+
+        /// <summary>
+        /// ログインプロンプト
+        /// </summary>
+        public string LoginPrompt {
+            get { return _loginPrompt; }
+            set { _loginPrompt = value; }
+        }
+
+        /// <summary>
+        /// パスワードプロンプト
+        /// </summary>
+        public string PasswordPrompt {
+            get { return _passwordPrompt; }
+            set { _passwordPrompt = value; }
+        }
+
+        /// <summary>
+        /// 実行コマンド
+        /// </summary>
+        public string ExecCommand {
+            get { return _execCommand; }
+            set { _execCommand = value; }
+        }
+
+        /// <summary>
+        /// SUユーザ名
+        /// </summary>
+        public string SUUserName {
+            get { return _suUserName; }
+            set { _suUserName = value; }
+        }
+
+        /// <summary>
+        /// SUパスワード
+        /// </summary>
+        public string SUPassword {
+            get { return _suPassword; }
+            set { _suPassword = value; }
+        }
+
+        /// <summary>
+        /// SUコマンド種類
+        /// </summary>
+        public string SUType {
+            get { return _suType; }
+            set { _suType = value; }
+        }
+
+        /// <summary>
+        /// 文字コード
+        /// </summary>
+        public EncodingType CharCode {
+            get { return _charCode; }
+            set { _charCode = value; }
+        }
+
+        /// <summary>
+        /// 改行コード
+        /// </summary>
+        public NewLine NewLine {
+            get { return _newLine; }
+            set { _newLine = value; }
+        }
+
+        /// <summary>
+        /// TelnetNewLine
+        /// </summary>
+        public bool TelnetNewLine {
+            get { return _telnetNewLine; }
+            set { _telnetNewLine = value; }
+        }
+
+        /// <summary>
+        /// ターミナル種類
+        /// </summary>
+        public TerminalType TerminalType {
+            get { return _terminalType; }
+            set { _terminalType = value; }
+        }
+
+        /// <summary>
+        /// フォント色
+        /// </summary>
+        public Color TerminalFontColor {
+            get { return _terminalFontColor; }
+            set { _terminalFontColor = value; }
+        }
+
+        /// <summary>
+        /// 背景色
+        /// </summary>
+        public Color TerminalBGColor {
+            get { return _terminalBGColor; }
+            set { _terminalBGColor = value; }
+        }
+
+        /// <summary>
+        /// コマンド発行間隔(ms)
+        /// </summary>
+        public int CommandSendInterval {
+            get { return _commandSendInterval; }
+            set { _commandSendInterval = value; }
+        }
+
+        /// <summary>
+        /// プロンプト受信タイムアウト(ms)
+        /// </summary>
+        public int PromptRecvTimeout {
+            get { return _promptRecvTimeout; }
+            set { _promptRecvTimeout = value; }
+        }
+
+        /// <summary>
+        /// プロファイル項目色
+        /// </summary>
+        public Color ProfileItemColor {
+            get { return _profileItemColor; }
+            set { _profileItemColor = value; }
+        }
+
+        /// <summary>
+        /// 説明
+        /// </summary>
+        public string Description {
+            get { return _description; }
+            set { _description = value; }
+        }
+
+        /// <summary>
+        /// リストチェック状態
+        /// </summary>
+        public bool Check {
+            get { return _checkState; }
+            set { _checkState = value; }
+        }
+    }
+}

--- a/ConnectProfile/ConnectProfilePlugin.cs
+++ b/ConnectProfile/ConnectProfilePlugin.cs
@@ -261,8 +261,8 @@ namespace Poderosa.ConnectProfile {
             _terminalType = builder.DefineStringValue(_profileDefinition, "terminalType", "", null);
             _terminalFontColor = new ColorPreferenceItem(builder.DefineStringValue(_profileDefinition, "terminalFontColor", "White", null), KnownColor.White);
             _terminalBGColor = new ColorPreferenceItem(builder.DefineStringValue(_profileDefinition, "terminalBGColor", "Black", null), KnownColor.Black);
-            _commandSendInterval = builder.DefineIntValue(_profileDefinition, "commandSendInterval", 500, null);
-            _promptRecvTimeout = builder.DefineIntValue(_profileDefinition, "promptRecvTimeout", 5000, null);
+            _commandSendInterval = builder.DefineIntValue(_profileDefinition, "commandSendInterval", ConnectProfileStruct.DEFAULT_CMD_SEND_INTERVAL, null);
+            _promptRecvTimeout = builder.DefineIntValue(_profileDefinition, "promptRecvTimeout", ConnectProfileStruct.DEFAULT_PROMPT_RECV_TIMEOUT, null);
             _profileItemColor = new ColorPreferenceItem(builder.DefineStringValue(_profileDefinition, "profileItemColor", "Black", null), KnownColor.Black);
             _description = builder.DefineStringValue(_profileDefinition, "description", "", null);
         }

--- a/ConnectProfile/ConnectProfilePlugin.cs
+++ b/ConnectProfile/ConnectProfilePlugin.cs
@@ -1,0 +1,405 @@
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+using Poderosa.Commands;
+using Poderosa.ConnectionParam;
+using Poderosa.Forms;
+using Poderosa.Plugins;
+using Poderosa.Preferences;
+using Poderosa.Protocols;
+using Poderosa.Sessions;
+using Poderosa.Terminal;
+
+
+/********* アセンブリ情報 *********/
+[assembly: PluginDeclaration(typeof(Poderosa.ConnectProfile.ConnectProfilePlugin))]
+/**********************************/
+
+
+namespace Poderosa.ConnectProfile {
+    /********* プラグイン情報 *********/
+    [PluginInfo(
+        ID           = PLUGIN_ID,
+        Version      = VersionInfo.PODEROSA_VERSION,
+        Author       = VersionInfo.PROJECT_NAME,
+        Dependencies = "org.poderosa.core.window"
+    )]
+    /**********************************/
+
+
+
+
+    /// <summary>
+    /// ConnectProfileプラグインメインクラス
+    /// </summary>
+    internal class ConnectProfilePlugin : PluginBase {
+        // メンバー変数
+        public const string PLUGIN_ID = "org.poderosa.connectprofile";
+        private static ConnectProfilePlugin _instance;
+        private static ICoreServices _coreServices;
+        private static ConnectProfileCommand _connectProfileCommand;
+        private static StringResource _stringResource;
+        private static ConnectProfileList _profiles;
+        private static ConnectProfileOptionsSupplier _connectProfileOptionSupplier;
+
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        public override void InitializePlugin(IPoderosaWorld poderosa) {
+            base.InitializePlugin(poderosa);
+            _instance = this;
+
+            // 文字列リソース読み込み
+            _stringResource = new StringResource("Poderosa.ConnectProfile.strings", typeof(ConnectProfilePlugin).Assembly);
+            ConnectProfilePlugin.Instance.PoderosaWorld.Culture.AddChangeListener(_stringResource);
+
+            // メニュー登録
+            IPluginManager pm = poderosa.PluginManager;
+            _coreServices = (ICoreServices)poderosa.GetAdapter(typeof(ICoreServices));
+            _connectProfileCommand = new ConnectProfileCommand();
+            _coreServices.CommandManager.Register(_connectProfileCommand);
+            IExtensionPoint toolmenu = pm.FindExtensionPoint("org.poderosa.menu.tool");
+            toolmenu.RegisterExtension(new PoderosaMenuGroupImpl(new IPoderosaMenu[] { new PoderosaMenuItemImpl(_connectProfileCommand, ConnectProfilePlugin.Strings, "Menu.ConnectProfile") }, false));
+
+            // 設定ファイル連携
+            _connectProfileOptionSupplier = new ConnectProfileOptionsSupplier();
+            _coreServices.PreferenceExtensionPoint.RegisterExtension(_connectProfileOptionSupplier);
+
+            // 接続プロファイル
+            _profiles = new ConnectProfileList();
+        }
+
+        /// <summary>
+        /// プラグイン終了
+        /// </summary>
+        public override void TerminatePlugin() {
+            base.TerminatePlugin();
+            _connectProfileOptionSupplier.SaveToPreference();
+        }
+
+        /// <summary>
+        /// メッセージ表示Delegate
+        /// </summary>
+        private delegate void MessageBoxDelegate(IWin32Window window, string msg, MessageBoxIcon icon);
+        /// <summary>
+        /// メッセージ表示Invoke
+        /// </summary>
+        /// <param name="msg">メッセージ文字列</param>
+        /// <param name="icon">アイコン</param>
+        public static void MessageBoxInvoke(string msg, MessageBoxIcon icon) {
+            Form f = ConnectProfilePlugin.Instance.WindowManager.ActiveWindow.AsForm();
+            f.Invoke(new MessageBoxDelegate(GUtil.Warning), f, msg, icon);
+        }
+
+        /// <summary>
+        /// 選択メッセージ表示Delegate
+        /// </summary>
+        private delegate DialogResult AskUserYesNoDelegate(IWin32Window window, string msg, MessageBoxIcon icon);
+        /// <summary>
+        /// 選択メッセージ表示Invoke
+        /// </summary>
+        /// <param name="msg">メッセージ文字列</param>
+        /// <param name="icon">アイコン</param>
+        public static DialogResult AskUserYesNoInvoke(string msg, MessageBoxIcon icon) {
+            Form f = ConnectProfilePlugin.Instance.WindowManager.ActiveWindow.AsForm();
+            return (DialogResult)f.Invoke(new AskUserYesNoDelegate(GUtil.AskUserYesNo), f, msg, icon);
+        }
+
+        /// <summary>
+        /// インスタンス
+        /// </summary>
+        public static ConnectProfilePlugin Instance {
+            get { return _instance; }
+        }
+
+        /// <summary>
+        /// 文字列リソース
+        /// </summary>
+        public static StringResource Strings {
+            get { return _stringResource; }
+        }
+
+        /// <summary>
+        /// プロファイルリスト
+        /// </summary>
+        public static ConnectProfileList Profiles {
+            get { return _profiles; }
+        }
+
+        /// <summary>
+        /// 設定ファイル
+        /// </summary>
+        public ConnectProfileOptionsSupplier ConnectProfileOptionSupplier {
+            get { return _connectProfileOptionSupplier; }
+        }
+
+        /// <summary>
+        /// CommandManager
+        /// </summary>
+        public ICommandManager CommandManager {
+            get { return _coreServices.CommandManager; }
+        }
+
+        /// <summary>
+        /// WindowManager
+        /// </summary>
+        public IWindowManager WindowManager {
+            get { return _coreServices.WindowManager; }
+        }
+
+        /// <summary>
+        /// TerminalEmulatorService
+        /// </summary>
+        public ITerminalEmulatorService TerminalEmulatorService {
+            get { return (ITerminalEmulatorService)_poderosaWorld.PluginManager.FindPlugin("org.poderosa.terminalemulator", typeof(ITerminalEmulatorService)); }
+        }
+
+        /// <summary>
+        /// TerminalSessionsService
+        /// </summary>
+        public ITerminalSessionsService TerminalSessionsService {
+            get { return (ITerminalSessionsService)_poderosaWorld.PluginManager.FindPlugin("org.poderosa.terminalsessions", typeof(ITerminalSessionsService)); }
+        }
+
+        /// <summary>
+        /// ProtocolService
+        /// </summary>
+        public IProtocolService ProtocolService {
+            get { return (IProtocolService)_poderosaWorld.PluginManager.FindPlugin("org.poderosa.protocols", typeof(IProtocolService)); }
+        }
+    }
+
+
+
+
+    /// <summary>
+    /// プラグイン実行クラス
+    /// </summary>
+    internal class ConnectProfileCommand : GeneralCommandImpl {
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        public ConnectProfileCommand()
+            : base(ConnectProfilePlugin.PLUGIN_ID, ConnectProfilePlugin.Strings, "Command.ConnectProfile", ConnectProfilePlugin.Instance.CommandManager.CommandCategories.Dialogs) {
+            return;
+        }
+
+        /// <summary>
+        /// プラグイン実行
+        /// </summary>
+        public override CommandResult InternalExecute(ICommandTarget target, params IAdaptable[] args) {
+            IPoderosaMainWindow window = CommandTargetUtil.AsWindow(target);
+            ConnectProfileForm Form = new ConnectProfileForm();
+            if (Form.ShowDialog(window.AsForm()) == DialogResult.OK) {
+                return CommandResult.Succeeded;
+            } else {
+                return CommandResult.Cancelled;
+            }
+        }
+    }
+
+
+
+
+    /// <summary>
+    /// 設定ファイル保存/読み込みクラス
+    /// </summary>
+    internal class ConnectProfileOptionsSupplier : IPreferenceSupplier {
+        // メンバー変数
+        private IPreferenceFolder _rootPreference;
+        private IPreferenceFolder _profileDefinition;
+        private IStringPreferenceItem _hostName;
+        private IStringPreferenceItem _protocol;
+        private IIntPreferenceItem _port;
+        private IStringPreferenceItem _authType;
+        private IStringPreferenceItem _keyFile;
+        private IStringPreferenceItem _userName;
+        private IStringPreferenceItem _password;
+        private IBoolPreferenceItem _autoLogin;
+        private IStringPreferenceItem _loginPrompt;
+        private IStringPreferenceItem _passwordPrompt;
+        private IStringPreferenceItem _execCommand;
+        private IStringPreferenceItem _suUserName;
+        private IStringPreferenceItem _suPassword;
+        private IStringPreferenceItem _suType;
+        private IStringPreferenceItem _charCode;
+        private IStringPreferenceItem _newLine;
+        private IBoolPreferenceItem _telnetNewLine;
+        private IStringPreferenceItem _terminalType;
+        private ColorPreferenceItem _terminalFontColor;
+        private ColorPreferenceItem _terminalBGColor;
+        private IIntPreferenceItem _commandSendInterval;
+        private IIntPreferenceItem _promptRecvTimeout;
+        private ColorPreferenceItem _profileItemColor;
+        private IStringPreferenceItem _description;
+        private bool _preferenceLoaded = false;
+
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        public void InitializePreference(IPreferenceBuilder builder, IPreferenceFolder folder) {
+            _rootPreference = folder;
+            _profileDefinition = builder.DefineFolderArray(folder, this, "profile");
+            _hostName = builder.DefineStringValue(_profileDefinition, "hostName", "", null);
+            _protocol = builder.DefineStringValue(_profileDefinition, "protocol", "", null);
+            _port = builder.DefineIntValue(_profileDefinition, "port", 0, null);
+            _authType = builder.DefineStringValue(_profileDefinition, "authType", "", null);
+            _keyFile = builder.DefineStringValue(_profileDefinition, "keyFile", "", null);
+            _userName = builder.DefineStringValue(_profileDefinition, "userName", "", null);
+            _password = builder.DefineStringValue(_profileDefinition, "password", "", null);
+            _autoLogin = builder.DefineBoolValue(_profileDefinition, "autoLogin", false, null);
+            _loginPrompt = builder.DefineStringValue(_profileDefinition, "loginPrompt", "", null);
+            _passwordPrompt = builder.DefineStringValue(_profileDefinition, "passwordPrompt", "", null);
+            _execCommand = builder.DefineStringValue(_profileDefinition, "execCommand", "", null);
+            _suUserName = builder.DefineStringValue(_profileDefinition, "suUserName", "", null);
+            _suPassword = builder.DefineStringValue(_profileDefinition, "suPassword", "", null);
+            _suType = builder.DefineStringValue(_profileDefinition, "suType", "", null);
+            _charCode = builder.DefineStringValue(_profileDefinition, "charCode", "", null);
+            _newLine = builder.DefineStringValue(_profileDefinition, "newLine", "", null);
+            _telnetNewLine = builder.DefineBoolValue(_profileDefinition, "telnetNewLine", true, null);
+            _terminalType = builder.DefineStringValue(_profileDefinition, "terminalType", "", null);
+            _terminalFontColor = new ColorPreferenceItem(builder.DefineStringValue(_profileDefinition, "terminalFontColor", "White", null), KnownColor.White);
+            _terminalBGColor = new ColorPreferenceItem(builder.DefineStringValue(_profileDefinition, "terminalBGColor", "Black", null), KnownColor.Black);
+            _commandSendInterval = builder.DefineIntValue(_profileDefinition, "commandSendInterval", 500, null);
+            _promptRecvTimeout = builder.DefineIntValue(_profileDefinition, "promptRecvTimeout", 5000, null);
+            _profileItemColor = new ColorPreferenceItem(builder.DefineStringValue(_profileDefinition, "profileItemColor", "Black", null), KnownColor.Black);
+            _description = builder.DefineStringValue(_profileDefinition, "description", "", null);
+        }
+
+        /// <summary>
+        /// 保存
+        /// </summary>
+        public void SaveToPreference() {
+            // 一度も読み込まれていない場合は読み込む(フォームが一度も表示されてない場合に設定が消滅してしまう)
+            if (this.PreferenceLoaded != true) this.LoadFromPreference();
+
+            IPreferenceFolderArray fa = _rootPreference.FindChildFolderArray(_profileDefinition.Id);
+            fa.Clear();
+
+            foreach (ConnectProfileStruct prof in ConnectProfilePlugin.Profiles) {
+                IPreferenceFolder f = fa.CreateNewFolder();
+
+                // パスワード暗号化
+                string pw = "";
+                string supw = "";
+                if (prof.Password != "") pw = new SimpleStringEncrypt().EncryptString(prof.Password);
+                if (prof.SUPassword != "") supw = new SimpleStringEncrypt().EncryptString(prof.SUPassword);
+
+                // 値代入
+                fa.ConvertItem(f, _hostName).AsString().Value = prof.HostName;
+                fa.ConvertItem(f, _protocol).AsString().Value = prof.Protocol.ToString();
+                fa.ConvertItem(f, _port).AsInt().Value = prof.Port;
+                fa.ConvertItem(f, _authType).AsString().Value = prof.AuthType.ToString();
+                fa.ConvertItem(f, _keyFile).AsString().Value = prof.KeyFile;
+                fa.ConvertItem(f, _userName).AsString().Value = prof.UserName;
+                fa.ConvertItem(f, _password).AsString().Value = (pw != null) ? pw : "";
+                fa.ConvertItem(f, _autoLogin).AsBool().Value = prof.AutoLogin;
+                fa.ConvertItem(f, _loginPrompt).AsString().Value = prof.LoginPrompt;
+                fa.ConvertItem(f, _passwordPrompt).AsString().Value = prof.PasswordPrompt;
+                fa.ConvertItem(f, _execCommand).AsString().Value = prof.ExecCommand;
+                fa.ConvertItem(f, _suUserName).AsString().Value = prof.SUUserName;
+                fa.ConvertItem(f, _suPassword).AsString().Value = (supw != null) ? supw : "";
+                fa.ConvertItem(f, _suType).AsString().Value = prof.SUType;
+                fa.ConvertItem(f, _charCode).AsString().Value = prof.CharCode.ToString();
+                fa.ConvertItem(f, _newLine).AsString().Value = prof.NewLine.ToString();
+                fa.ConvertItem(f, _telnetNewLine).AsBool().Value = prof.TelnetNewLine;
+                fa.ConvertItem(f, _terminalType).AsString().Value = prof.TerminalType.ToString();
+                fa.ConvertItem(f, _terminalFontColor.PreferenceItem).AsString().Value = Convert.ToString(prof.TerminalFontColor.ToArgb(), 16);
+                fa.ConvertItem(f, _terminalBGColor.PreferenceItem).AsString().Value = Convert.ToString(prof.TerminalBGColor.ToArgb(), 16);
+                fa.ConvertItem(f, _commandSendInterval).AsInt().Value = prof.CommandSendInterval;
+                fa.ConvertItem(f, _promptRecvTimeout).AsInt().Value = prof.PromptRecvTimeout;
+                fa.ConvertItem(f, _profileItemColor.PreferenceItem).AsString().Value = Convert.ToString(prof.ProfileItemColor.ToArgb(), 16);
+                fa.ConvertItem(f, _description).AsString().Value = prof.Description;
+            }
+        }
+
+        /// <summary>
+        /// 読み込み
+        /// </summary>
+        public void LoadFromPreference() {
+            IPreferenceFolderArray fa = _rootPreference.FindChildFolderArray(_profileDefinition.Id);
+
+            foreach (IPreferenceFolder f in fa.Folders) {
+                ConnectProfileStruct prof = new ConnectProfileStruct();
+                prof.HostName = fa.ConvertItem(f, _hostName).AsString().Value;
+                if (fa.ConvertItem(f, _protocol).AsString().Value == "Telnet") prof.Protocol = ConnectionMethod.Telnet;
+                else if (fa.ConvertItem(f, _protocol).AsString().Value == "SSH1") prof.Protocol = ConnectionMethod.SSH1;
+                else if (fa.ConvertItem(f, _protocol).AsString().Value == "SSH2") prof.Protocol = ConnectionMethod.SSH2;
+                prof.Port = fa.ConvertItem(f, _port).AsInt().Value;
+                if (fa.ConvertItem(f, _authType).AsString().Value == "Password") prof.AuthType = AuthType.Password;
+                else if (fa.ConvertItem(f, _authType).AsString().Value == "PublicKey") prof.AuthType = AuthType.PublicKey;
+                else if (fa.ConvertItem(f, _authType).AsString().Value == "KeyboardInteractive") prof.AuthType = AuthType.KeyboardInteractive;
+                prof.KeyFile = fa.ConvertItem(f, _keyFile).AsString().Value;
+                prof.UserName = fa.ConvertItem(f, _userName).AsString().Value;
+                prof.Password = fa.ConvertItem(f, _password).AsString().Value;
+                prof.AutoLogin = fa.ConvertItem(f, _autoLogin).AsBool().Value;
+                prof.LoginPrompt = fa.ConvertItem(f, _loginPrompt).AsString().Value;
+                prof.PasswordPrompt = fa.ConvertItem(f, _passwordPrompt).AsString().Value;
+                prof.ExecCommand = fa.ConvertItem(f, _execCommand).AsString().Value;
+                prof.SUUserName = fa.ConvertItem(f, _suUserName).AsString().Value;
+                prof.SUPassword = fa.ConvertItem(f, _suPassword).AsString().Value;
+                prof.SUType = fa.ConvertItem(f, _suType).AsString().Value;
+                if (fa.ConvertItem(f, _charCode).AsString().Value == "ISO8859_1") prof.CharCode = EncodingType.ISO8859_1;
+                else if (fa.ConvertItem(f, _charCode).AsString().Value == "UTF8") prof.CharCode = EncodingType.UTF8;
+                else if (fa.ConvertItem(f, _charCode).AsString().Value == "EUC_JP") prof.CharCode = EncodingType.EUC_JP;
+                else if (fa.ConvertItem(f, _charCode).AsString().Value == "SHIFT_JIS") prof.CharCode = EncodingType.SHIFT_JIS;
+                else if (fa.ConvertItem(f, _charCode).AsString().Value == "GB2312") prof.CharCode = EncodingType.GB2312;
+                else if (fa.ConvertItem(f, _charCode).AsString().Value == "BIG5") prof.CharCode = EncodingType.BIG5;
+                else if (fa.ConvertItem(f, _charCode).AsString().Value == "EUC_CN") prof.CharCode = EncodingType.EUC_CN;
+                else if (fa.ConvertItem(f, _charCode).AsString().Value == "EUC_KR") prof.CharCode = EncodingType.EUC_KR;
+                else if (fa.ConvertItem(f, _charCode).AsString().Value == "UTF8_Latin") prof.CharCode = EncodingType.UTF8_Latin;
+                else if (fa.ConvertItem(f, _charCode).AsString().Value == "OEM850") prof.CharCode = EncodingType.OEM850;
+                if (fa.ConvertItem(f, _newLine).AsString().Value == "CR") prof.NewLine = NewLine.CR;
+                else if (fa.ConvertItem(f, _newLine).AsString().Value == "LF") prof.NewLine = NewLine.LF;
+                else if (fa.ConvertItem(f, _newLine).AsString().Value == "CRLF") prof.NewLine = NewLine.CRLF;
+                prof.TelnetNewLine = fa.ConvertItem(f, _telnetNewLine).AsBool().Value;
+                if (fa.ConvertItem(f, _terminalType).AsString().Value == "KTerm") prof.TerminalType = TerminalType.KTerm;
+                else if (fa.ConvertItem(f, _terminalType).AsString().Value == "VT100") prof.TerminalType = TerminalType.VT100;
+                else if (fa.ConvertItem(f, _terminalType).AsString().Value == "XTerm") prof.TerminalType = TerminalType.XTerm;
+                prof.TerminalFontColor = ParseUtil.ParseColor(fa.ConvertItem(f, _terminalFontColor.PreferenceItem).AsString().Value, Color.White);
+                prof.TerminalBGColor = ParseUtil.ParseColor(fa.ConvertItem(f, _terminalBGColor.PreferenceItem).AsString().Value, Color.Black);
+                prof.CommandSendInterval = fa.ConvertItem(f, _commandSendInterval).AsInt().Value;
+                prof.PromptRecvTimeout = fa.ConvertItem(f, _promptRecvTimeout).AsInt().Value;
+                prof.ProfileItemColor = ParseUtil.ParseColor(fa.ConvertItem(f, _profileItemColor.PreferenceItem).AsString().Value, Color.Black);
+                prof.Description = fa.ConvertItem(f, _description).AsString().Value;
+
+                // パスワード複合化
+                if (prof.Password != "") prof.Password = new SimpleStringEncrypt().DecryptString(prof.Password);
+                if (prof.SUPassword != "") prof.SUPassword = new SimpleStringEncrypt().DecryptString(prof.SUPassword);
+
+                ConnectProfilePlugin.Profiles.AddProfile(prof);
+            }
+
+            _preferenceLoaded = true;
+        }
+
+        /// <summary>
+        /// ValidateFolder
+        /// </summary>
+        public void ValidateFolder(IPreferenceFolder folder, IPreferenceValidationResult output) {
+            return;
+        }
+
+        /// <summary>
+        /// QueryAdapter
+        /// </summary>
+        public object QueryAdapter(IPreferenceFolder folder, Type type) {
+            return null;
+        }
+
+        /// <summary>
+        /// プラグインID
+        /// </summary>
+        public string PreferenceID {
+            get { return ConnectProfilePlugin.PLUGIN_ID; }
+        }
+
+        /// <summary>
+        /// 読み込み完了フラグ
+        /// </summary>
+        public bool PreferenceLoaded {
+            get { return _preferenceLoaded; }
+        }
+    }
+}

--- a/ConnectProfile/ProfileEditForm.Designer.cs
+++ b/ConnectProfile/ProfileEditForm.Designer.cs
@@ -1,0 +1,883 @@
+﻿namespace Poderosa.ConnectProfile {
+    partial class ProfileEditForm {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing) {
+            if (disposing && (components != null)) {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent() {
+            this._hostNameBox = new Poderosa.UI.WaterMarkTextBox();
+            this._hostNameLabel = new System.Windows.Forms.Label();
+            this._userNameLabel = new System.Windows.Forms.Label();
+            this._userNameBox = new Poderosa.UI.WaterMarkTextBox();
+            this._passwordLabel = new System.Windows.Forms.Label();
+            this._basicGroup = new System.Windows.Forms.GroupBox();
+            this._portBox = new System.Windows.Forms.NumericUpDown();
+            this._protocolBox = new System.Windows.Forms.ComboBox();
+            this._portLabel = new System.Windows.Forms.Label();
+            this._protocolLabel = new System.Windows.Forms.Label();
+            this._passwordPromptBox = new Poderosa.UI.WaterMarkTextBox();
+            this._passwordPromptLabel = new System.Windows.Forms.Label();
+            this._loginPromptBox = new Poderosa.UI.WaterMarkTextBox();
+            this._loginPromptLabel = new System.Windows.Forms.Label();
+            this._autoLoginCheck = new System.Windows.Forms.CheckBox();
+            this._passwordBox = new Poderosa.UI.WaterMarkTextBox();
+            this._sshGroup = new System.Windows.Forms.GroupBox();
+            this._authTypeBox = new System.Windows.Forms.ComboBox();
+            this._keyFileBox = new Poderosa.UI.WaterMarkTextBox();
+            this._openKeyFileButton = new System.Windows.Forms.Button();
+            this._keyFileLabel = new System.Windows.Forms.Label();
+            this._authTypeLabel = new System.Windows.Forms.Label();
+            this._okButton = new System.Windows.Forms.Button();
+            this._cancelButton = new System.Windows.Forms.Button();
+            this._suGroup = new System.Windows.Forms.GroupBox();
+            this._suTypeRadio2 = new System.Windows.Forms.RadioButton();
+            this._suUserNameBox = new Poderosa.UI.WaterMarkTextBox();
+            this._suPasswordBox = new Poderosa.UI.WaterMarkTextBox();
+            this._suTypeRadio1 = new System.Windows.Forms.RadioButton();
+            this._suTypeLabel = new System.Windows.Forms.Label();
+            this._suUserNameLabel = new System.Windows.Forms.Label();
+            this._suPasswordLabel = new System.Windows.Forms.Label();
+            this._etcGroup = new System.Windows.Forms.GroupBox();
+            this._promptRecvTimeoutBox = new System.Windows.Forms.NumericUpDown();
+            this._commandSendIntBox = new System.Windows.Forms.NumericUpDown();
+            this._descriptionBox = new Poderosa.UI.WaterMarkTextBox();
+            this._profileItemColorButton = new Poderosa.UI.ColorButton();
+            this._promptRecvTimeoutLabel = new System.Windows.Forms.Label();
+            this._commandSendIntLabel = new System.Windows.Forms.Label();
+            this._descriptionLabel = new System.Windows.Forms.Label();
+            this._profileItemColorLabel = new System.Windows.Forms.Label();
+            this._terminalFontColorButton = new Poderosa.UI.ColorButton();
+            this._terminalFontColorLabel = new System.Windows.Forms.Label();
+            this._terminalBGColorButton = new Poderosa.UI.ColorButton();
+            this._terminalBGColorLabel = new System.Windows.Forms.Label();
+            this._execCommandBox = new Poderosa.UI.WaterMarkTextBox();
+            this._execCommandLabel = new System.Windows.Forms.Label();
+            this._charCodeLabel = new System.Windows.Forms.Label();
+            this._charCodeBox = new System.Windows.Forms.ComboBox();
+            this._terminalGroup = new System.Windows.Forms.GroupBox();
+            this._telnetNewLineCheck = new System.Windows.Forms.CheckBox();
+            this._terminalTypeBox = new System.Windows.Forms.ComboBox();
+            this._newLineTypeBox = new System.Windows.Forms.ComboBox();
+            this._newLineTypeLabel = new System.Windows.Forms.Label();
+            this._terminalTypeLabel = new System.Windows.Forms.Label();
+            this._hintLabel = new System.Windows.Forms.Label();
+            this._autoLoginGroup = new System.Windows.Forms.GroupBox();
+            this._accountGroup = new System.Windows.Forms.GroupBox();
+            this._basicGroup.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this._portBox)).BeginInit();
+            this._sshGroup.SuspendLayout();
+            this._suGroup.SuspendLayout();
+            this._etcGroup.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this._promptRecvTimeoutBox)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this._commandSendIntBox)).BeginInit();
+            this._terminalGroup.SuspendLayout();
+            this._autoLoginGroup.SuspendLayout();
+            this._accountGroup.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // _hostNameBox
+            // 
+            this._hostNameBox.Location = new System.Drawing.Point(109, 22);
+            this._hostNameBox.Name = "_hostNameBox";
+            this._hostNameBox.Size = new System.Drawing.Size(131, 19);
+            this._hostNameBox.TabIndex = 0;
+            this._hostNameBox.WaterMarkAlsoFocus = true;
+            this._hostNameBox.WaterMarkColor = System.Drawing.Color.Gray;
+            this._hostNameBox.WaterMarkText = "";
+            this._hostNameBox.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _hostNameLabel
+            // 
+            this._hostNameLabel.AutoSize = true;
+            this._hostNameLabel.Location = new System.Drawing.Point(6, 25);
+            this._hostNameLabel.Name = "_hostNameLabel";
+            this._hostNameLabel.Size = new System.Drawing.Size(87, 12);
+            this._hostNameLabel.TabIndex = 1;
+            this._hostNameLabel.Text = "_hostNameLabel";
+            // 
+            // _userNameLabel
+            // 
+            this._userNameLabel.AutoSize = true;
+            this._userNameLabel.Location = new System.Drawing.Point(6, 24);
+            this._userNameLabel.Name = "_userNameLabel";
+            this._userNameLabel.Size = new System.Drawing.Size(87, 12);
+            this._userNameLabel.TabIndex = 2;
+            this._userNameLabel.Text = "_userNameLabel";
+            // 
+            // _userNameBox
+            // 
+            this._userNameBox.Location = new System.Drawing.Point(109, 21);
+            this._userNameBox.Name = "_userNameBox";
+            this._userNameBox.Size = new System.Drawing.Size(131, 19);
+            this._userNameBox.TabIndex = 2;
+            this._userNameBox.WaterMarkAlsoFocus = true;
+            this._userNameBox.WaterMarkColor = System.Drawing.Color.Gray;
+            this._userNameBox.WaterMarkText = "";
+            this._userNameBox.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _passwordLabel
+            // 
+            this._passwordLabel.AutoSize = true;
+            this._passwordLabel.Location = new System.Drawing.Point(6, 49);
+            this._passwordLabel.Name = "_passwordLabel";
+            this._passwordLabel.Size = new System.Drawing.Size(84, 12);
+            this._passwordLabel.TabIndex = 4;
+            this._passwordLabel.Text = "_passwordLabel";
+            // 
+            // _basicGroup
+            // 
+            this._basicGroup.Controls.Add(this._portBox);
+            this._basicGroup.Controls.Add(this._hostNameBox);
+            this._basicGroup.Controls.Add(this._protocolBox);
+            this._basicGroup.Controls.Add(this._hostNameLabel);
+            this._basicGroup.Controls.Add(this._portLabel);
+            this._basicGroup.Controls.Add(this._protocolLabel);
+            this._basicGroup.Location = new System.Drawing.Point(12, 12);
+            this._basicGroup.Name = "_basicGroup";
+            this._basicGroup.Size = new System.Drawing.Size(251, 104);
+            this._basicGroup.TabIndex = 0;
+            this._basicGroup.TabStop = false;
+            this._basicGroup.Text = "_basicGroup";
+            // 
+            // _portBox
+            // 
+            this._portBox.Location = new System.Drawing.Point(109, 73);
+            this._portBox.Maximum = new decimal(new int[] {
+            65535,
+            0,
+            0,
+            0});
+            this._portBox.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this._portBox.Name = "_portBox";
+            this._portBox.Size = new System.Drawing.Size(131, 19);
+            this._portBox.TabIndex = 2;
+            this._portBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            this._portBox.Value = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this._portBox.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _protocolBox
+            // 
+            this._protocolBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this._protocolBox.FormattingEnabled = true;
+            this._protocolBox.Location = new System.Drawing.Point(109, 47);
+            this._protocolBox.Name = "_protocolBox";
+            this._protocolBox.Size = new System.Drawing.Size(131, 20);
+            this._protocolBox.TabIndex = 1;
+            this._protocolBox.Tag = "";
+            this._protocolBox.SelectedIndexChanged += new System.EventHandler(this.EnableValidControls);
+            this._protocolBox.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _portLabel
+            // 
+            this._portLabel.AutoSize = true;
+            this._portLabel.Location = new System.Drawing.Point(6, 75);
+            this._portLabel.Name = "_portLabel";
+            this._portLabel.Size = new System.Drawing.Size(56, 12);
+            this._portLabel.TabIndex = 4;
+            this._portLabel.Text = "_portLabel";
+            // 
+            // _protocolLabel
+            // 
+            this._protocolLabel.AutoSize = true;
+            this._protocolLabel.Location = new System.Drawing.Point(6, 50);
+            this._protocolLabel.Name = "_protocolLabel";
+            this._protocolLabel.Size = new System.Drawing.Size(77, 12);
+            this._protocolLabel.TabIndex = 1;
+            this._protocolLabel.Text = "_protocolLabel";
+            // 
+            // _passwordPromptBox
+            // 
+            this._passwordPromptBox.Location = new System.Drawing.Point(109, 69);
+            this._passwordPromptBox.Name = "_passwordPromptBox";
+            this._passwordPromptBox.Size = new System.Drawing.Size(131, 19);
+            this._passwordPromptBox.TabIndex = 2;
+            this._passwordPromptBox.WaterMarkAlsoFocus = true;
+            this._passwordPromptBox.WaterMarkColor = System.Drawing.Color.Gray;
+            this._passwordPromptBox.WaterMarkText = "";
+            this._passwordPromptBox.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _passwordPromptLabel
+            // 
+            this._passwordPromptLabel.AutoSize = true;
+            this._passwordPromptLabel.Location = new System.Drawing.Point(6, 72);
+            this._passwordPromptLabel.Name = "_passwordPromptLabel";
+            this._passwordPromptLabel.Size = new System.Drawing.Size(120, 12);
+            this._passwordPromptLabel.TabIndex = 10;
+            this._passwordPromptLabel.Text = "_passwordPromptLabel";
+            // 
+            // _loginPromptBox
+            // 
+            this._loginPromptBox.Location = new System.Drawing.Point(109, 44);
+            this._loginPromptBox.Name = "_loginPromptBox";
+            this._loginPromptBox.Size = new System.Drawing.Size(131, 19);
+            this._loginPromptBox.TabIndex = 1;
+            this._loginPromptBox.WaterMarkAlsoFocus = true;
+            this._loginPromptBox.WaterMarkColor = System.Drawing.Color.Gray;
+            this._loginPromptBox.WaterMarkText = "";
+            this._loginPromptBox.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _loginPromptLabel
+            // 
+            this._loginPromptLabel.AutoSize = true;
+            this._loginPromptLabel.Location = new System.Drawing.Point(6, 47);
+            this._loginPromptLabel.Name = "_loginPromptLabel";
+            this._loginPromptLabel.Size = new System.Drawing.Size(96, 12);
+            this._loginPromptLabel.TabIndex = 8;
+            this._loginPromptLabel.Text = "_loginPromptLabel";
+            // 
+            // _autoLoginCheck
+            // 
+            this._autoLoginCheck.Location = new System.Drawing.Point(8, 22);
+            this._autoLoginCheck.Name = "_autoLoginCheck";
+            this._autoLoginCheck.Size = new System.Drawing.Size(131, 16);
+            this._autoLoginCheck.TabIndex = 0;
+            this._autoLoginCheck.Text = "_autoLoginCheck";
+            this._autoLoginCheck.UseVisualStyleBackColor = true;
+            this._autoLoginCheck.CheckedChanged += new System.EventHandler(this.EnableValidControls);
+            this._autoLoginCheck.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _passwordBox
+            // 
+            this._passwordBox.Location = new System.Drawing.Point(109, 46);
+            this._passwordBox.Name = "_passwordBox";
+            this._passwordBox.Size = new System.Drawing.Size(131, 19);
+            this._passwordBox.TabIndex = 3;
+            this._passwordBox.UseSystemPasswordChar = true;
+            this._passwordBox.WaterMarkAlsoFocus = true;
+            this._passwordBox.WaterMarkColor = System.Drawing.Color.Gray;
+            this._passwordBox.WaterMarkText = "";
+            this._passwordBox.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _sshGroup
+            // 
+            this._sshGroup.Controls.Add(this._authTypeBox);
+            this._sshGroup.Controls.Add(this._keyFileBox);
+            this._sshGroup.Controls.Add(this._openKeyFileButton);
+            this._sshGroup.Controls.Add(this._keyFileLabel);
+            this._sshGroup.Controls.Add(this._authTypeLabel);
+            this._sshGroup.Location = new System.Drawing.Point(12, 122);
+            this._sshGroup.Name = "_sshGroup";
+            this._sshGroup.Size = new System.Drawing.Size(251, 75);
+            this._sshGroup.TabIndex = 1;
+            this._sshGroup.TabStop = false;
+            this._sshGroup.Text = "_sshGroup";
+            // 
+            // _authTypeBox
+            // 
+            this._authTypeBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this._authTypeBox.FormattingEnabled = true;
+            this._authTypeBox.Location = new System.Drawing.Point(109, 21);
+            this._authTypeBox.Name = "_authTypeBox";
+            this._authTypeBox.Size = new System.Drawing.Size(131, 20);
+            this._authTypeBox.TabIndex = 0;
+            this._authTypeBox.SelectedIndexChanged += new System.EventHandler(this.EnableValidControls);
+            this._authTypeBox.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _keyFileBox
+            // 
+            this._keyFileBox.Enabled = false;
+            this._keyFileBox.Location = new System.Drawing.Point(109, 47);
+            this._keyFileBox.Name = "_keyFileBox";
+            this._keyFileBox.Size = new System.Drawing.Size(106, 19);
+            this._keyFileBox.TabIndex = 1;
+            this._keyFileBox.WaterMarkAlsoFocus = true;
+            this._keyFileBox.WaterMarkColor = System.Drawing.Color.Gray;
+            this._keyFileBox.WaterMarkText = "";
+            this._keyFileBox.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _openKeyFileButton
+            // 
+            this._openKeyFileButton.Enabled = false;
+            this._openKeyFileButton.Location = new System.Drawing.Point(221, 47);
+            this._openKeyFileButton.Name = "_openKeyFileButton";
+            this._openKeyFileButton.Size = new System.Drawing.Size(19, 19);
+            this._openKeyFileButton.TabIndex = 2;
+            this._openKeyFileButton.Text = "...";
+            this._openKeyFileButton.UseVisualStyleBackColor = true;
+            this._openKeyFileButton.Click += new System.EventHandler(this._openKeyFileButton_Click);
+            this._openKeyFileButton.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _keyFileLabel
+            // 
+            this._keyFileLabel.AutoSize = true;
+            this._keyFileLabel.Location = new System.Drawing.Point(6, 50);
+            this._keyFileLabel.Name = "_keyFileLabel";
+            this._keyFileLabel.Size = new System.Drawing.Size(73, 12);
+            this._keyFileLabel.TabIndex = 4;
+            this._keyFileLabel.Text = "_keyFileLabel";
+            // 
+            // _authTypeLabel
+            // 
+            this._authTypeLabel.AutoSize = true;
+            this._authTypeLabel.Location = new System.Drawing.Point(6, 24);
+            this._authTypeLabel.Name = "_authTypeLabel";
+            this._authTypeLabel.Size = new System.Drawing.Size(83, 12);
+            this._authTypeLabel.TabIndex = 1;
+            this._authTypeLabel.Text = "_authTypeLabel";
+            // 
+            // _okButton
+            // 
+            this._okButton.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this._okButton.Location = new System.Drawing.Point(269, 491);
+            this._okButton.Name = "_okButton";
+            this._okButton.Size = new System.Drawing.Size(116, 23);
+            this._okButton.TabIndex = 7;
+            this._okButton.Text = "_okButton";
+            this._okButton.UseVisualStyleBackColor = true;
+            this._okButton.Click += new System.EventHandler(this._okButton_Click);
+            this._okButton.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _cancelButton
+            // 
+            this._cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this._cancelButton.Location = new System.Drawing.Point(403, 491);
+            this._cancelButton.Name = "_cancelButton";
+            this._cancelButton.Size = new System.Drawing.Size(116, 23);
+            this._cancelButton.TabIndex = 8;
+            this._cancelButton.Text = "_cancelButton";
+            this._cancelButton.UseVisualStyleBackColor = true;
+            this._cancelButton.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _suGroup
+            // 
+            this._suGroup.Controls.Add(this._suTypeRadio2);
+            this._suGroup.Controls.Add(this._suUserNameBox);
+            this._suGroup.Controls.Add(this._suPasswordBox);
+            this._suGroup.Controls.Add(this._suTypeRadio1);
+            this._suGroup.Controls.Add(this._suTypeLabel);
+            this._suGroup.Controls.Add(this._suUserNameLabel);
+            this._suGroup.Controls.Add(this._suPasswordLabel);
+            this._suGroup.Location = new System.Drawing.Point(8, 119);
+            this._suGroup.Name = "_suGroup";
+            this._suGroup.Size = new System.Drawing.Size(232, 100);
+            this._suGroup.TabIndex = 4;
+            this._suGroup.TabStop = false;
+            this._suGroup.Text = "_suGroup";
+            // 
+            // _suTypeRadio2
+            // 
+            this._suTypeRadio2.Location = new System.Drawing.Point(165, 71);
+            this._suTypeRadio2.Name = "_suTypeRadio2";
+            this._suTypeRadio2.Size = new System.Drawing.Size(67, 18);
+            this._suTypeRadio2.TabIndex = 3;
+            this._suTypeRadio2.TabStop = true;
+            this._suTypeRadio2.Text = "_suTypeRadio2";
+            this._suTypeRadio2.UseVisualStyleBackColor = true;
+            this._suTypeRadio2.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _suUserNameBox
+            // 
+            this._suUserNameBox.Location = new System.Drawing.Point(101, 21);
+            this._suUserNameBox.Name = "_suUserNameBox";
+            this._suUserNameBox.Size = new System.Drawing.Size(125, 19);
+            this._suUserNameBox.TabIndex = 0;
+            this._suUserNameBox.WaterMarkAlsoFocus = true;
+            this._suUserNameBox.WaterMarkColor = System.Drawing.Color.Gray;
+            this._suUserNameBox.WaterMarkText = "";
+            this._suUserNameBox.TextChanged += new System.EventHandler(this.EnableValidControls);
+            this._suUserNameBox.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _suPasswordBox
+            // 
+            this._suPasswordBox.Enabled = false;
+            this._suPasswordBox.Location = new System.Drawing.Point(101, 46);
+            this._suPasswordBox.Name = "_suPasswordBox";
+            this._suPasswordBox.Size = new System.Drawing.Size(125, 19);
+            this._suPasswordBox.TabIndex = 1;
+            this._suPasswordBox.UseSystemPasswordChar = true;
+            this._suPasswordBox.WaterMarkAlsoFocus = true;
+            this._suPasswordBox.WaterMarkColor = System.Drawing.Color.Gray;
+            this._suPasswordBox.WaterMarkText = "";
+            this._suPasswordBox.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _suTypeRadio1
+            // 
+            this._suTypeRadio1.Location = new System.Drawing.Point(101, 71);
+            this._suTypeRadio1.Name = "_suTypeRadio1";
+            this._suTypeRadio1.Size = new System.Drawing.Size(58, 18);
+            this._suTypeRadio1.TabIndex = 2;
+            this._suTypeRadio1.TabStop = true;
+            this._suTypeRadio1.Text = "_suTypeRadio1";
+            this._suTypeRadio1.UseVisualStyleBackColor = true;
+            this._suTypeRadio1.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _suTypeLabel
+            // 
+            this._suTypeLabel.AutoSize = true;
+            this._suTypeLabel.Location = new System.Drawing.Point(6, 74);
+            this._suTypeLabel.Name = "_suTypeLabel";
+            this._suTypeLabel.Size = new System.Drawing.Size(73, 12);
+            this._suTypeLabel.TabIndex = 4;
+            this._suTypeLabel.Text = "_suTypeLabel";
+            // 
+            // _suUserNameLabel
+            // 
+            this._suUserNameLabel.AutoSize = true;
+            this._suUserNameLabel.Location = new System.Drawing.Point(6, 24);
+            this._suUserNameLabel.Name = "_suUserNameLabel";
+            this._suUserNameLabel.Size = new System.Drawing.Size(101, 12);
+            this._suUserNameLabel.TabIndex = 1;
+            this._suUserNameLabel.Text = "_suUserNameLabel";
+            // 
+            // _suPasswordLabel
+            // 
+            this._suPasswordLabel.AutoSize = true;
+            this._suPasswordLabel.Location = new System.Drawing.Point(6, 49);
+            this._suPasswordLabel.Name = "_suPasswordLabel";
+            this._suPasswordLabel.Size = new System.Drawing.Size(97, 12);
+            this._suPasswordLabel.TabIndex = 2;
+            this._suPasswordLabel.Text = "_suPasswordLabel";
+            // 
+            // _etcGroup
+            // 
+            this._etcGroup.Controls.Add(this._promptRecvTimeoutBox);
+            this._etcGroup.Controls.Add(this._commandSendIntBox);
+            this._etcGroup.Controls.Add(this._descriptionBox);
+            this._etcGroup.Controls.Add(this._profileItemColorButton);
+            this._etcGroup.Controls.Add(this._promptRecvTimeoutLabel);
+            this._etcGroup.Controls.Add(this._commandSendIntLabel);
+            this._etcGroup.Controls.Add(this._descriptionLabel);
+            this._etcGroup.Controls.Add(this._profileItemColorLabel);
+            this._etcGroup.Location = new System.Drawing.Point(269, 203);
+            this._etcGroup.Name = "_etcGroup";
+            this._etcGroup.Size = new System.Drawing.Size(250, 132);
+            this._etcGroup.TabIndex = 6;
+            this._etcGroup.TabStop = false;
+            this._etcGroup.Text = "_etcGroup";
+            // 
+            // _promptRecvTimeoutBox
+            // 
+            this._promptRecvTimeoutBox.Increment = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            this._promptRecvTimeoutBox.Location = new System.Drawing.Point(188, 47);
+            this._promptRecvTimeoutBox.Maximum = new decimal(new int[] {
+            60000,
+            0,
+            0,
+            0});
+            this._promptRecvTimeoutBox.Minimum = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            this._promptRecvTimeoutBox.Name = "_promptRecvTimeoutBox";
+            this._promptRecvTimeoutBox.Size = new System.Drawing.Size(56, 19);
+            this._promptRecvTimeoutBox.TabIndex = 1;
+            this._promptRecvTimeoutBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            this._promptRecvTimeoutBox.Value = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            this._promptRecvTimeoutBox.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _commandSendIntBox
+            // 
+            this._commandSendIntBox.Increment = new decimal(new int[] {
+            100,
+            0,
+            0,
+            0});
+            this._commandSendIntBox.Location = new System.Drawing.Point(188, 22);
+            this._commandSendIntBox.Maximum = new decimal(new int[] {
+            10000,
+            0,
+            0,
+            0});
+            this._commandSendIntBox.Minimum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            0});
+            this._commandSendIntBox.Name = "_commandSendIntBox";
+            this._commandSendIntBox.Size = new System.Drawing.Size(56, 19);
+            this._commandSendIntBox.TabIndex = 0;
+            this._commandSendIntBox.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            this._commandSendIntBox.Value = new decimal(new int[] {
+            100,
+            0,
+            0,
+            0});
+            this._commandSendIntBox.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _descriptionBox
+            // 
+            this._descriptionBox.Location = new System.Drawing.Point(113, 101);
+            this._descriptionBox.Name = "_descriptionBox";
+            this._descriptionBox.Size = new System.Drawing.Size(131, 19);
+            this._descriptionBox.TabIndex = 3;
+            this._descriptionBox.WaterMarkAlsoFocus = true;
+            this._descriptionBox.WaterMarkColor = System.Drawing.Color.Gray;
+            this._descriptionBox.WaterMarkText = "";
+            this._descriptionBox.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _profileItemColorButton
+            // 
+            this._profileItemColorButton.BackColor = System.Drawing.SystemColors.Control;
+            this._profileItemColorButton.Location = new System.Drawing.Point(113, 72);
+            this._profileItemColorButton.Name = "_profileItemColorButton";
+            this._profileItemColorButton.SelectedColor = System.Drawing.Color.Black;
+            this._profileItemColorButton.Size = new System.Drawing.Size(131, 23);
+            this._profileItemColorButton.TabIndex = 2;
+            this._profileItemColorButton.UseVisualStyleBackColor = false;
+            this._profileItemColorButton.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _promptRecvTimeoutLabel
+            // 
+            this._promptRecvTimeoutLabel.AutoSize = true;
+            this._promptRecvTimeoutLabel.Location = new System.Drawing.Point(6, 49);
+            this._promptRecvTimeoutLabel.Name = "_promptRecvTimeoutLabel";
+            this._promptRecvTimeoutLabel.Size = new System.Drawing.Size(138, 12);
+            this._promptRecvTimeoutLabel.TabIndex = 28;
+            this._promptRecvTimeoutLabel.Text = "_promptRecvTimeoutLabel";
+            // 
+            // _commandSendIntLabel
+            // 
+            this._commandSendIntLabel.AutoSize = true;
+            this._commandSendIntLabel.Location = new System.Drawing.Point(6, 24);
+            this._commandSendIntLabel.Name = "_commandSendIntLabel";
+            this._commandSendIntLabel.Size = new System.Drawing.Size(122, 12);
+            this._commandSendIntLabel.TabIndex = 26;
+            this._commandSendIntLabel.Text = "_commandSendIntLabel";
+            // 
+            // _descriptionLabel
+            // 
+            this._descriptionLabel.AutoSize = true;
+            this._descriptionLabel.Location = new System.Drawing.Point(6, 104);
+            this._descriptionLabel.Name = "_descriptionLabel";
+            this._descriptionLabel.Size = new System.Drawing.Size(92, 12);
+            this._descriptionLabel.TabIndex = 13;
+            this._descriptionLabel.Text = "_descriptionLabel";
+            // 
+            // _profileItemColorLabel
+            // 
+            this._profileItemColorLabel.AutoSize = true;
+            this._profileItemColorLabel.Location = new System.Drawing.Point(6, 77);
+            this._profileItemColorLabel.Name = "_profileItemColorLabel";
+            this._profileItemColorLabel.Size = new System.Drawing.Size(117, 12);
+            this._profileItemColorLabel.TabIndex = 11;
+            this._profileItemColorLabel.Text = "_profileItemColorLabel";
+            // 
+            // _terminalFontColorButton
+            // 
+            this._terminalFontColorButton.BackColor = System.Drawing.SystemColors.Control;
+            this._terminalFontColorButton.Location = new System.Drawing.Point(109, 121);
+            this._terminalFontColorButton.Name = "_terminalFontColorButton";
+            this._terminalFontColorButton.SelectedColor = System.Drawing.Color.Black;
+            this._terminalFontColorButton.Size = new System.Drawing.Size(131, 23);
+            this._terminalFontColorButton.TabIndex = 4;
+            this._terminalFontColorButton.UseVisualStyleBackColor = false;
+            this._terminalFontColorButton.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _terminalFontColorLabel
+            // 
+            this._terminalFontColorLabel.AutoSize = true;
+            this._terminalFontColorLabel.Location = new System.Drawing.Point(6, 126);
+            this._terminalFontColorLabel.Name = "_terminalFontColorLabel";
+            this._terminalFontColorLabel.Size = new System.Drawing.Size(127, 12);
+            this._terminalFontColorLabel.TabIndex = 22;
+            this._terminalFontColorLabel.Text = "_terminalFontColorLabel";
+            // 
+            // _terminalBGColorButton
+            // 
+            this._terminalBGColorButton.BackColor = System.Drawing.SystemColors.Control;
+            this._terminalBGColorButton.Location = new System.Drawing.Point(109, 149);
+            this._terminalBGColorButton.Name = "_terminalBGColorButton";
+            this._terminalBGColorButton.SelectedColor = System.Drawing.Color.Black;
+            this._terminalBGColorButton.Size = new System.Drawing.Size(131, 23);
+            this._terminalBGColorButton.TabIndex = 5;
+            this._terminalBGColorButton.UseVisualStyleBackColor = false;
+            this._terminalBGColorButton.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _terminalBGColorLabel
+            // 
+            this._terminalBGColorLabel.AutoSize = true;
+            this._terminalBGColorLabel.Location = new System.Drawing.Point(6, 154);
+            this._terminalBGColorLabel.Name = "_terminalBGColorLabel";
+            this._terminalBGColorLabel.Size = new System.Drawing.Size(120, 12);
+            this._terminalBGColorLabel.TabIndex = 4;
+            this._terminalBGColorLabel.Text = "_terminalBGColorLabel";
+            // 
+            // _execCommandBox
+            // 
+            this._execCommandBox.Location = new System.Drawing.Point(109, 94);
+            this._execCommandBox.Name = "_execCommandBox";
+            this._execCommandBox.Size = new System.Drawing.Size(131, 19);
+            this._execCommandBox.TabIndex = 3;
+            this._execCommandBox.WaterMarkAlsoFocus = true;
+            this._execCommandBox.WaterMarkColor = System.Drawing.Color.Gray;
+            this._execCommandBox.WaterMarkText = "";
+            this._execCommandBox.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _execCommandLabel
+            // 
+            this._execCommandLabel.AutoSize = true;
+            this._execCommandLabel.Location = new System.Drawing.Point(6, 97);
+            this._execCommandLabel.Name = "_execCommandLabel";
+            this._execCommandLabel.Size = new System.Drawing.Size(110, 12);
+            this._execCommandLabel.TabIndex = 2;
+            this._execCommandLabel.Text = "_execCommandLabel";
+            // 
+            // _charCodeLabel
+            // 
+            this._charCodeLabel.AutoSize = true;
+            this._charCodeLabel.Location = new System.Drawing.Point(6, 24);
+            this._charCodeLabel.Name = "_charCodeLabel";
+            this._charCodeLabel.Size = new System.Drawing.Size(84, 12);
+            this._charCodeLabel.TabIndex = 1;
+            this._charCodeLabel.Text = "_charCodeLabel";
+            // 
+            // _charCodeBox
+            // 
+            this._charCodeBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this._charCodeBox.FormattingEnabled = true;
+            this._charCodeBox.Location = new System.Drawing.Point(109, 21);
+            this._charCodeBox.Name = "_charCodeBox";
+            this._charCodeBox.Size = new System.Drawing.Size(131, 20);
+            this._charCodeBox.TabIndex = 0;
+            this._charCodeBox.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _terminalGroup
+            // 
+            this._terminalGroup.Controls.Add(this._terminalFontColorButton);
+            this._terminalGroup.Controls.Add(this._telnetNewLineCheck);
+            this._terminalGroup.Controls.Add(this._charCodeBox);
+            this._terminalGroup.Controls.Add(this._terminalBGColorButton);
+            this._terminalGroup.Controls.Add(this._terminalTypeBox);
+            this._terminalGroup.Controls.Add(this._newLineTypeBox);
+            this._terminalGroup.Controls.Add(this._terminalFontColorLabel);
+            this._terminalGroup.Controls.Add(this._charCodeLabel);
+            this._terminalGroup.Controls.Add(this._newLineTypeLabel);
+            this._terminalGroup.Controls.Add(this._terminalBGColorLabel);
+            this._terminalGroup.Controls.Add(this._terminalTypeLabel);
+            this._terminalGroup.Location = new System.Drawing.Point(269, 12);
+            this._terminalGroup.Name = "_terminalGroup";
+            this._terminalGroup.Size = new System.Drawing.Size(250, 185);
+            this._terminalGroup.TabIndex = 5;
+            this._terminalGroup.TabStop = false;
+            this._terminalGroup.Text = "_terminalGroup";
+            // 
+            // _telnetNewLineCheck
+            // 
+            this._telnetNewLineCheck.Location = new System.Drawing.Point(109, 73);
+            this._telnetNewLineCheck.Name = "_telnetNewLineCheck";
+            this._telnetNewLineCheck.Size = new System.Drawing.Size(131, 16);
+            this._telnetNewLineCheck.TabIndex = 2;
+            this._telnetNewLineCheck.Text = "_telnetNewLineCheck";
+            this._telnetNewLineCheck.UseVisualStyleBackColor = true;
+            this._telnetNewLineCheck.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _terminalTypeBox
+            // 
+            this._terminalTypeBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this._terminalTypeBox.FormattingEnabled = true;
+            this._terminalTypeBox.Location = new System.Drawing.Point(109, 95);
+            this._terminalTypeBox.Name = "_terminalTypeBox";
+            this._terminalTypeBox.Size = new System.Drawing.Size(131, 20);
+            this._terminalTypeBox.TabIndex = 3;
+            this._terminalTypeBox.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _newLineTypeBox
+            // 
+            this._newLineTypeBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this._newLineTypeBox.FormattingEnabled = true;
+            this._newLineTypeBox.Location = new System.Drawing.Point(109, 47);
+            this._newLineTypeBox.Name = "_newLineTypeBox";
+            this._newLineTypeBox.Size = new System.Drawing.Size(131, 20);
+            this._newLineTypeBox.TabIndex = 1;
+            this._newLineTypeBox.SelectedIndexChanged += new System.EventHandler(this.EnableValidControls);
+            this._newLineTypeBox.Enter += new System.EventHandler(this.ShowHint);
+            // 
+            // _newLineTypeLabel
+            // 
+            this._newLineTypeLabel.AutoSize = true;
+            this._newLineTypeLabel.Location = new System.Drawing.Point(6, 50);
+            this._newLineTypeLabel.Name = "_newLineTypeLabel";
+            this._newLineTypeLabel.Size = new System.Drawing.Size(102, 12);
+            this._newLineTypeLabel.TabIndex = 18;
+            this._newLineTypeLabel.Text = "_newLineTypeLabel";
+            // 
+            // _terminalTypeLabel
+            // 
+            this._terminalTypeLabel.AutoSize = true;
+            this._terminalTypeLabel.Location = new System.Drawing.Point(6, 98);
+            this._terminalTypeLabel.Name = "_terminalTypeLabel";
+            this._terminalTypeLabel.Size = new System.Drawing.Size(102, 12);
+            this._terminalTypeLabel.TabIndex = 20;
+            this._terminalTypeLabel.Text = "_terminalTypeLabel";
+            // 
+            // _hintLabel
+            // 
+            this._hintLabel.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+            this._hintLabel.Location = new System.Drawing.Point(269, 338);
+            this._hintLabel.Name = "_hintLabel";
+            this._hintLabel.Size = new System.Drawing.Size(250, 150);
+            this._hintLabel.TabIndex = 28;
+            this._hintLabel.Text = "_hintLabel";
+            // 
+            // _autoLoginGroup
+            // 
+            this._autoLoginGroup.Controls.Add(this._execCommandBox);
+            this._autoLoginGroup.Controls.Add(this._autoLoginCheck);
+            this._autoLoginGroup.Controls.Add(this._passwordPromptBox);
+            this._autoLoginGroup.Controls.Add(this._loginPromptBox);
+            this._autoLoginGroup.Controls.Add(this._loginPromptLabel);
+            this._autoLoginGroup.Controls.Add(this._suGroup);
+            this._autoLoginGroup.Controls.Add(this._execCommandLabel);
+            this._autoLoginGroup.Controls.Add(this._passwordPromptLabel);
+            this._autoLoginGroup.Location = new System.Drawing.Point(12, 284);
+            this._autoLoginGroup.Name = "_autoLoginGroup";
+            this._autoLoginGroup.Size = new System.Drawing.Size(251, 230);
+            this._autoLoginGroup.TabIndex = 3;
+            this._autoLoginGroup.TabStop = false;
+            this._autoLoginGroup.Text = "_autoLoginGroup";
+            // 
+            // _accountGroup
+            // 
+            this._accountGroup.Controls.Add(this._passwordBox);
+            this._accountGroup.Controls.Add(this._userNameBox);
+            this._accountGroup.Controls.Add(this._passwordLabel);
+            this._accountGroup.Controls.Add(this._userNameLabel);
+            this._accountGroup.Location = new System.Drawing.Point(12, 203);
+            this._accountGroup.Name = "_accountGroup";
+            this._accountGroup.Size = new System.Drawing.Size(251, 75);
+            this._accountGroup.TabIndex = 2;
+            this._accountGroup.TabStop = false;
+            this._accountGroup.Text = "_accountGroup";
+            // 
+            // ProfileEditForm
+            // 
+            this.AcceptButton = this._okButton;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this._cancelButton;
+            this.ClientSize = new System.Drawing.Size(527, 522);
+            this.Controls.Add(this._accountGroup);
+            this.Controls.Add(this._autoLoginGroup);
+            this.Controls.Add(this._hintLabel);
+            this.Controls.Add(this._terminalGroup);
+            this.Controls.Add(this._etcGroup);
+            this.Controls.Add(this._cancelButton);
+            this.Controls.Add(this._okButton);
+            this.Controls.Add(this._sshGroup);
+            this.Controls.Add(this._basicGroup);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "ProfileEditForm";
+            this.ShowIcon = false;
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "ProfileEdit";
+            this._basicGroup.ResumeLayout(false);
+            this._basicGroup.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this._portBox)).EndInit();
+            this._sshGroup.ResumeLayout(false);
+            this._sshGroup.PerformLayout();
+            this._suGroup.ResumeLayout(false);
+            this._suGroup.PerformLayout();
+            this._etcGroup.ResumeLayout(false);
+            this._etcGroup.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this._promptRecvTimeoutBox)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this._commandSendIntBox)).EndInit();
+            this._terminalGroup.ResumeLayout(false);
+            this._terminalGroup.PerformLayout();
+            this._autoLoginGroup.ResumeLayout(false);
+            this._autoLoginGroup.PerformLayout();
+            this._accountGroup.ResumeLayout(false);
+            this._accountGroup.PerformLayout();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private Poderosa.UI.WaterMarkTextBox _hostNameBox;
+        private System.Windows.Forms.Label _hostNameLabel;
+        private System.Windows.Forms.Label _userNameLabel;
+        private Poderosa.UI.WaterMarkTextBox _userNameBox;
+        private System.Windows.Forms.Label _passwordLabel;
+        private System.Windows.Forms.GroupBox _basicGroup;
+        private Poderosa.UI.WaterMarkTextBox _passwordBox;
+        private System.Windows.Forms.ComboBox _protocolBox;
+        private System.Windows.Forms.Label _portLabel;
+        private System.Windows.Forms.Label _protocolLabel;
+        private System.Windows.Forms.GroupBox _sshGroup;
+        private Poderosa.UI.WaterMarkTextBox _keyFileBox;
+        private System.Windows.Forms.Button _openKeyFileButton;
+        private System.Windows.Forms.ComboBox _authTypeBox;
+        private System.Windows.Forms.Label _keyFileLabel;
+        private System.Windows.Forms.Label _authTypeLabel;
+        private System.Windows.Forms.Button _okButton;
+        private System.Windows.Forms.Button _cancelButton;
+        private System.Windows.Forms.GroupBox _suGroup;
+        private System.Windows.Forms.RadioButton _suTypeRadio2;
+        private System.Windows.Forms.Label _suTypeLabel;
+        private System.Windows.Forms.RadioButton _suTypeRadio1;
+        private Poderosa.UI.WaterMarkTextBox _suUserNameBox;
+        private System.Windows.Forms.Label _suUserNameLabel;
+        private Poderosa.UI.WaterMarkTextBox _suPasswordBox;
+        private System.Windows.Forms.Label _suPasswordLabel;
+        private Poderosa.UI.WaterMarkTextBox _descriptionBox;
+        private System.Windows.Forms.Label _descriptionLabel;
+        private System.Windows.Forms.Label _profileItemColorLabel;
+        private System.Windows.Forms.ComboBox _charCodeBox;
+        private System.Windows.Forms.Label _terminalBGColorLabel;
+        private System.Windows.Forms.Label _charCodeLabel;
+        private Poderosa.UI.WaterMarkTextBox _execCommandBox;
+        private System.Windows.Forms.Label _execCommandLabel;
+        private UI.ColorButton _profileItemColorButton;
+        private UI.ColorButton _terminalBGColorButton;
+        private System.Windows.Forms.GroupBox _etcGroup;
+        private UI.ColorButton _terminalFontColorButton;
+        private System.Windows.Forms.Label _terminalFontColorLabel;
+        private System.Windows.Forms.GroupBox _terminalGroup;
+        private System.Windows.Forms.ComboBox _terminalTypeBox;
+        private System.Windows.Forms.Label _terminalTypeLabel;
+        private System.Windows.Forms.ComboBox _newLineTypeBox;
+        private System.Windows.Forms.Label _newLineTypeLabel;
+        private Poderosa.UI.WaterMarkTextBox _passwordPromptBox;
+        private System.Windows.Forms.Label _passwordPromptLabel;
+        private Poderosa.UI.WaterMarkTextBox _loginPromptBox;
+        private System.Windows.Forms.Label _loginPromptLabel;
+        private System.Windows.Forms.CheckBox _autoLoginCheck;
+        private System.Windows.Forms.Label _hintLabel;
+        private System.Windows.Forms.NumericUpDown _portBox;
+        private System.Windows.Forms.NumericUpDown _promptRecvTimeoutBox;
+        private System.Windows.Forms.Label _promptRecvTimeoutLabel;
+        private System.Windows.Forms.NumericUpDown _commandSendIntBox;
+        private System.Windows.Forms.Label _commandSendIntLabel;
+        private System.Windows.Forms.CheckBox _telnetNewLineCheck;
+        private System.Windows.Forms.GroupBox _autoLoginGroup;
+        private System.Windows.Forms.GroupBox _accountGroup;
+    }
+}

--- a/ConnectProfile/ProfileEditForm.cs
+++ b/ConnectProfile/ProfileEditForm.cs
@@ -1,0 +1,344 @@
+﻿using System;
+using System.IO;
+using System.Windows.Forms;
+
+using Poderosa.ConnectionParam;
+using Poderosa.Terminal;
+using Poderosa.UI;
+using Poderosa.Util;
+
+
+namespace Poderosa.ConnectProfile {
+    /// <summary>
+    /// プロファイルの追加/編集フォームクラス
+    /// </summary>
+    public partial class ProfileEditForm : Form {
+        private ConnectProfileStruct _result;
+        private bool _Initialized = false;
+
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        /// <param name="prof">プロファイル</param>
+        public ProfileEditForm(ConnectProfileStruct prof) {
+            InitializeComponent();
+            InitializeComponentValue();
+
+            // オブジェクト初期値設定
+            if (prof == null) {
+                // 新規作成時はデフォルト値を設定(フォント色/背景色はターミナルオプション値を反映)
+                ITerminalEmulatorOptions terminalOptions = ConnectProfilePlugin.Instance.TerminalEmulatorService.TerminalEmulatorOptions;
+                _protocolBox.SelectedItem = ConnectionMethod.SSH2;
+                _portBox.Value = ConnectProfileStruct.DEFAULT_SSH_PORT;
+                _authTypeBox.SelectedItem = AuthType.Password;
+                _charCodeBox.SelectedItem = EncodingType.UTF8;
+                _newLineTypeBox.SelectedItem = NewLine.CR;
+                _telnetNewLineCheck.Checked = true;
+                _terminalTypeBox.SelectedItem = TerminalType.XTerm;
+                _terminalFontColorButton.SelectedColor = terminalOptions.TextColor;
+                _terminalBGColorButton.SelectedColor = terminalOptions.BGColor;
+                _commandSendIntBox.Value = ConnectProfileStruct.DEFAULT_CMD_SEND_INTERVAL;
+                _promptRecvTimeoutBox.Value = ConnectProfileStruct.DEFAULT_PROMPT_RECV_TIMEOUT;
+            } else {
+                // 編集時は対象プロファイル値を設定
+                _hostNameBox.Text = prof.HostName;
+                _protocolBox.SelectedItem = prof.Protocol;
+                _portBox.Value = prof.Port;
+                _authTypeBox.SelectedItem = prof.AuthType;
+                _keyFileBox.Text = prof.KeyFile;
+                _userNameBox.Text = prof.UserName;
+                _passwordBox.Text = prof.Password;
+                _autoLoginCheck.Checked = prof.AutoLogin;
+                _loginPromptBox.Text = prof.LoginPrompt;
+                _passwordPromptBox.Text = prof.PasswordPrompt;
+                _execCommandBox.Text = prof.ExecCommand;
+                _suUserNameBox.Text = prof.SUUserName;
+                _suPasswordBox.Text = prof.SUPassword;
+                if (prof.SUType == _suTypeRadio1.Text) _suTypeRadio1.Checked = true;
+                else if (prof.SUType == _suTypeRadio2.Text) _suTypeRadio2.Checked = true;
+                _charCodeBox.SelectedItem = prof.CharCode;
+                _newLineTypeBox.SelectedItem = prof.NewLine;
+                _telnetNewLineCheck.Checked = prof.TelnetNewLine;
+                _terminalTypeBox.SelectedItem = prof.TerminalType;
+                _terminalFontColorButton.SelectedColor = prof.TerminalFontColor;
+                _terminalBGColorButton.SelectedColor = prof.TerminalBGColor;
+                _commandSendIntBox.Value = prof.CommandSendInterval;
+                _promptRecvTimeoutBox.Value = prof.PromptRecvTimeout;
+                _profileItemColorButton.SelectedColor = prof.ProfileItemColor;
+                _descriptionBox.Text = prof.Description;
+            }
+
+            _Initialized = true;
+            EnableValidControls(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// オブジェクトの各値を設定
+        /// </summary>
+        private void InitializeComponentValue() {
+            // テキスト
+            this.Text = ConnectProfilePlugin.Strings.GetString("Caption.AddProfile");
+            this._accountGroup.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._accountGroup");
+            this._authTypeLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._authTypeLabel");
+            this._autoLoginCheck.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._autoLoginCheck");
+            this._autoLoginGroup.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._autoLoginGroup");
+            this._basicGroup.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._basicGroup");
+            this._cancelButton.Text = ConnectProfilePlugin.Strings.GetString("Form.Common._cancelButton");
+            this._charCodeLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._charCodeLabel");
+            this._commandSendIntLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._commandSendIntLabel");
+            this._descriptionLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._descriptionLabel");
+            this._etcGroup.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._etcGroup");
+            this._execCommandLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._execCommandLabel");
+            this._hostNameLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._hostNameLabel");
+            this._keyFileLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._keyFileLabel");
+            this._loginPromptLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._loginPromptLabel");
+            this._newLineTypeLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._newLineTypeLabel");
+            this._okButton.Text = ConnectProfilePlugin.Strings.GetString("Form.Common._okButton");
+            this._openKeyFileButton.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._openKeyFileButton");
+            this._passwordLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._passwordLabel");
+            this._passwordPromptLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._passwordPromptLabel");
+            this._portLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._portLabel");
+            this._profileItemColorLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._profileItemColorLabel");
+            this._promptRecvTimeoutLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._promptRecvTimeoutLabel");
+            this._protocolLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._protocolLabel");
+            this._sshGroup.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._sshGroup");
+            this._suGroup.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._suGroup");
+            this._suPasswordLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._suPasswordLabel");
+            this._suTypeLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._suTypeLabel");
+            this._suTypeRadio1.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._suTypeRadio1");
+            this._suTypeRadio2.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._suTypeRadio2");
+            this._suUserNameLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._suUserNameLabel");
+            this._telnetNewLineCheck.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._telnetNewLineCheck");
+            this._terminalBGColorLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._terminalBGColorLabel");
+            this._terminalFontColorLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._terminalFontColorLabel");
+            this._terminalGroup.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._terminalGroup");
+            this._terminalTypeLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._terminalTypeLabel");
+            this._userNameLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile._userNameLabel");
+
+            // コンボボックス
+            this._charCodeBox.Items.AddRange(EnumListItem<EncodingType>.GetListItems());
+            this._authTypeBox.Items.AddRange(EnumListItem<AuthType>.GetListItems());
+            this._newLineTypeBox.Items.AddRange(EnumListItem<NewLine>.GetListItems());
+            this._terminalTypeBox.Items.AddRange(EnumListItem<TerminalType>.GetListItems());
+            this._protocolBox.Items.AddRange(new object[] {
+                new ListItem<ConnectionMethod>(ConnectionMethod.Telnet,ConnectionMethod.Telnet.ToString()),
+                new ListItem<ConnectionMethod>(ConnectionMethod.SSH1, ConnectionMethod.SSH1.ToString()),
+                new ListItem<ConnectionMethod>(ConnectionMethod.SSH2, ConnectionMethod.SSH2.ToString()),
+            });
+        }
+
+        /// <summary>
+        /// オブジェクトを有効/無効化(オブジェクト共通)
+        /// </summary>
+        private void EnableValidControls(object sender, EventArgs e) {
+            if (_Initialized == true) {
+                ConnectionMethod protocol = ((ListItem<ConnectionMethod>)_protocolBox.SelectedItem).Value;
+                EnumListItem<AuthType> authTypeItem = (EnumListItem<AuthType>)_authTypeBox.SelectedItem;
+                EnumListItem<NewLine> newLineItem = (EnumListItem<NewLine>)_newLineTypeBox.SelectedItem;
+                bool autologin = (_autoLoginCheck.Checked);
+                bool ssh = (protocol == ConnectionMethod.SSH1 || protocol == ConnectionMethod.SSH2);
+                bool pubkey = (authTypeItem != null && authTypeItem.Value == AuthType.PublicKey);
+                bool kbd = (authTypeItem != null && authTypeItem.Value == AuthType.KeyboardInteractive);
+                bool newline = (newLineItem != null && newLineItem.Value == NewLine.CRLF);
+                bool su = (_suUserNameBox.Text != "");
+                string watermarktext = ConnectProfilePlugin.Strings.GetString("Form.Common.WaterMark.Required");
+
+                // ユーザ名/パスワード
+                _userNameBox.Enabled = (ssh || autologin);
+                _passwordBox.Enabled = autologin;
+
+                // 自動ログイン用プロンプト
+                _loginPromptBox.Enabled = (autologin && !ssh);
+                _passwordPromptBox.Enabled = ((autologin && !ssh) || (autologin && su));
+
+                // 秘密鍵ファイル
+                _authTypeBox.Enabled = ssh;
+                _keyFileBox.Enabled = (ssh && pubkey);
+                _openKeyFileButton.Enabled = (ssh && pubkey);
+
+                // 実行コマンド
+                _execCommandBox.Enabled = autologin;
+
+                // SU
+                _suUserNameBox.Enabled = autologin;
+                _suPasswordBox.Enabled = (su && autologin);
+                _suTypeRadio1.Enabled = (su && autologin);
+                _suTypeRadio2.Enabled = (su && autologin);
+
+                // TelnetNewLine
+                _telnetNewLineCheck.Enabled = (!ssh && newline);
+
+                // コマンド発行間隔/プロンプト受信タイムアウト
+                _commandSendIntBox.Enabled = autologin;
+                _promptRecvTimeoutBox.Enabled = autologin;
+
+                // ポート番号
+                _portBox.Value = ssh ? ConnectProfileStruct.DEFAULT_SSH_PORT : ConnectProfileStruct.DEFAULT_TELNET_PORT;
+
+                // ウォーターマーク
+                _hostNameBox.WaterMarkText = watermarktext;
+                _userNameBox.WaterMarkText = (_userNameBox.Enabled) ? watermarktext : "";
+                _keyFileBox.WaterMarkText = (_keyFileBox.Enabled) ? watermarktext : "";
+                _loginPromptBox.WaterMarkText = (_loginPromptBox.Enabled) ? watermarktext : "";
+                _passwordPromptBox.WaterMarkText = (_passwordPromptBox.Enabled) ? watermarktext : "";
+            }
+        }
+
+        /// <summary>
+        /// 説明文を表示(オブジェクト共通)
+        /// </summary>
+        private void ShowHint(object sender, EventArgs e) {
+            if (sender == _hostNameBox) {
+                this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile.Hint._hostNameBox");
+            } else if (sender == _protocolBox) {
+                this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile.Hint._protocolBox");
+            } else if (sender == _portBox) {
+                this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile.Hint._portBox");
+            } else if (sender == _authTypeBox) {
+                this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile.Hint._authTypeBox");
+            } else if (sender == _keyFileBox) {
+                this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile.Hint._keyFileBox");
+            } else if (sender == _userNameBox) {
+                this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile.Hint._userNameBox");
+            } else if (sender == _passwordBox) {
+                this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile.Hint._passwordBox");
+            } else if (sender == _autoLoginCheck) {
+                this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile.Hint._autoLoginCheck");
+            } else if (sender == _loginPromptBox) {
+                this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile.Hint._loginPromptBox");
+            } else if (sender == _passwordPromptBox) {
+                this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile.Hint._passwordPromptBox");
+            } else if (sender == _execCommandBox) {
+                this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile.Hint._execCommandBox");
+            } else if (sender == _suUserNameBox) {
+                this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile.Hint._suUserNameBox");
+            } else if (sender == _suPasswordBox) {
+                this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile.Hint._suPasswordBox");
+            } else if ((sender == _suTypeRadio1) || sender == _suTypeRadio2) {
+                this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile.Hint._suTypeRadio");
+            } else if (sender == _charCodeBox) {
+                this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile.Hint._charCodeBox");
+            } else if (sender == _newLineTypeBox) {
+                this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile.Hint._newLineTypeBox");
+            } else if (sender == _telnetNewLineCheck) {
+                this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile.Hint._telnetNewLineCheck");
+            } else if (sender == _terminalTypeBox) {
+                this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile.Hint._terminalTypeBox");
+            } else if (sender == _terminalFontColorButton) {
+                this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile.Hint._terminalFontColorButton");
+            } else if (sender == _terminalBGColorButton) {
+                this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile.Hint._terminalBGColorButton");
+            } else if (sender == _commandSendIntBox) {
+                this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile.Hint._commandSendIntBox");
+            } else if (sender == _promptRecvTimeoutBox) {
+                this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile.Hint._promptRecvTimeoutBox");
+            } else if (sender == _profileItemColorButton) {
+                this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile.Hint._profileItemColorButton");
+            } else if (sender == _descriptionBox) {
+                this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile.Hint._descriptionBox");
+            } else {
+                this._hintLabel.Text = ConnectProfilePlugin.Strings.GetString("Form.AddProfile.Hint.None");
+            }
+        }
+
+        /// <summary>
+        /// OKボタンクリックイベント
+        /// </summary>
+        private void _okButton_Click(object sender, EventArgs e) {
+            this.DialogResult = DialogResult.None;
+
+            // 入力チェック
+            try {
+                // 初期化
+                _result = new ConnectProfileStruct();
+                _result.HostName = _hostNameBox.Text;
+                _result.Protocol = ((ListItem<ConnectionMethod>)_protocolBox.SelectedItem).Value;
+                _result.Port = (int)_portBox.Value;
+                _result.AuthType = ((EnumListItem<AuthType>)_authTypeBox.SelectedItem).Value;
+                _result.KeyFile = "";
+                _result.UserName = "";
+                _result.Password = _passwordBox.Text;
+                _result.AutoLogin = _autoLoginCheck.Checked;
+                _result.LoginPrompt = "";
+                _result.PasswordPrompt = "";
+                _result.ExecCommand = "";
+                _result.SUUserName = "";
+                _result.SUPassword = "";
+                _result.SUType = "";
+                _result.CharCode = ((EnumListItem<EncodingType>)_charCodeBox.SelectedItem).Value;
+                _result.NewLine = ((EnumListItem<NewLine>)_newLineTypeBox.SelectedItem).Value;
+                _result.TelnetNewLine = _telnetNewLineCheck.Checked;
+                _result.TerminalType = ((EnumListItem<TerminalType>)_terminalTypeBox.SelectedItem).Value;
+                _result.TerminalFontColor = _terminalFontColorButton.SelectedColor;
+                _result.TerminalBGColor = _terminalBGColorButton.SelectedColor;
+                _result.CommandSendInterval = (int)_commandSendIntBox.Value;
+                _result.PromptRecvTimeout = (int)_promptRecvTimeoutBox.Value;
+                _result.ProfileItemColor = _profileItemColorButton.SelectedColor;
+                _result.Description = _descriptionBox.Text;
+
+                // ホスト名
+                if (_hostNameBox.Text == "") throw new Exception(ConnectProfilePlugin.Strings.GetString("Message.AddProfile.EmptyHostName"));
+
+                // 秘密鍵ファイル
+                if (_keyFileBox.Enabled == true) {
+                    if (_keyFileBox.Text != "") {
+                        if (File.Exists(_keyFileBox.Text)) _result.KeyFile = _keyFileBox.Text;
+                        else throw new Exception(ConnectProfilePlugin.Strings.GetString("Message.AddProfile.KeyFileNotExist"));
+                    } else {
+                        throw new Exception(ConnectProfilePlugin.Strings.GetString("Message.AddProfile.EmptyKeyFile"));
+                    }
+                }
+
+                // ユーザ名
+                if (_userNameBox.Enabled == true) {
+                    if (_userNameBox.Text != "") _result.UserName = _userNameBox.Text;
+                    else throw new Exception(ConnectProfilePlugin.Strings.GetString("Message.AddProfile.EmptyUserName"));
+                }
+
+                // ログインプロンプト
+                if (_loginPromptBox.Enabled == true) {
+                    if (_loginPromptBox.Text != "") _result.LoginPrompt = _loginPromptBox.Text;
+                    else throw new Exception(ConnectProfilePlugin.Strings.GetString("Message.AddProfile.EmptyLoginPrompt"));
+                }
+
+                // パスワードプロンプト
+                if (_passwordPromptBox.Enabled == true) {
+                    if (_passwordPromptBox.Text != "") _result.PasswordPrompt = _passwordPromptBox.Text;
+                    else throw new Exception(ConnectProfilePlugin.Strings.GetString("Message.AddProfile.EmptyPasswordPrompt"));
+                }
+
+                // 実行コマンド
+                if ((_execCommandBox.Enabled == true) && _execCommandBox.Text != "") _result.ExecCommand = _execCommandBox.Text;
+
+                // SU
+                if ((_suUserNameBox.Enabled == true) && _suUserNameBox.Text != "") {
+                    _result.SUUserName = _suUserNameBox.Text;
+                    _result.SUPassword = _suPasswordBox.Text;
+                    if (_suTypeRadio1.Checked == true) _result.SUType = _suTypeRadio1.Text;
+                    else if (_suTypeRadio2.Checked == true) _result.SUType = _suTypeRadio2.Text;
+                    else throw new Exception(ConnectProfilePlugin.Strings.GetString("Message.AddProfile.SUTypeNotSelect"));
+                }
+
+                this.DialogResult = DialogResult.OK;
+            } catch (Exception ex) {
+                ConnectProfilePlugin.MessageBoxInvoke(ex.Message, MessageBoxIcon.Warning);
+            }
+        }
+
+        /// <summary>
+        /// 秘密鍵ファイル選択ボタンクリックイベント
+        /// </summary>
+        private void _openKeyFileButton_Click(object sender, EventArgs e) {
+            string fn = TerminalUtil.SelectPrivateKeyFileByDialog(this);
+            if (fn != null) _keyFileBox.Text = fn;
+            _keyFileBox.Focus();
+        }
+
+        /// <summary>
+        /// 設定済みプロファイル
+        /// </summary>
+        public ConnectProfileStruct ResultProfile {
+            get { return _result; }
+        }
+    }
+}

--- a/ConnectProfile/ProfileEditForm.resx
+++ b/ConnectProfile/ProfileEditForm.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>53</value>
+  </metadata>
+</root>

--- a/ConnectProfile/Properties/AssemblyInfo.cs
+++ b/ConnectProfile/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// アセンブリに関する一般情報は以下の属性セットをとおして制御されます。
+// アセンブリに関連付けられている情報を変更するには、
+// これらの属性値を変更してください。
+[assembly: AssemblyTitle("ConnectProfile")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ConnectProfile")]
+[assembly: AssemblyCopyright("Copyright (C)  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// ComVisible を false に設定すると、その型はこのアセンブリ内で COM コンポーネントから 
+// 参照不可能になります。COM からこのアセンブリ内の型にアクセスする場合は、
+// その型の ComVisible 属性を true に設定してください。
+[assembly: ComVisible(false)]
+
+// 次の GUID は、このプロジェクトが COM に公開される場合の、typelib の ID です
+[assembly: Guid("d69f495b-2d45-4121-907c-b5b646570fbd")]
+
+// アセンブリのバージョン情報は、以下の 4 つの値で構成されています:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// すべての値を指定するか、下のように '*' を使ってビルドおよびリビジョン番号を 
+// 既定値にすることができます:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ConnectProfile/stringresource.xml
+++ b/ConnectProfile/stringresource.xml
@@ -11,6 +11,11 @@
   <en>Telnet/SSH Connection Profile</en>
 </record>
 
+<record name="Caption.ConnectProfile.Connecting">
+  <ja>Telnet/SSH接続プロファイル ({0} に接続中)</ja>
+  <en>Telnet/SSH Connection Profile (Connecting to {0})</en>
+</record>
+
 <record name="Command.ConnectProfile">
   <ja>Telnet/SSH接続プロファイル</ja>
   <en>Telnet/SSH Connection Profile</en>
@@ -216,10 +221,12 @@ Unit is milliseconds.</en>
 
 <record name="Form.AddProfile.Hint._execCommandBox">
    <ja>自動ログイン完了後に実行するコマンドをワンライナーで入力します。
-この機能を使用する場合は注意してください。
+SUスイッチ機能を使用する場合は、SUスイッチ後に実行されます。
+この機能を使用する場合は十分注意してください。
 未入力の場合はこの機能は使用されません。</ja>
-   <en>Enter the one-liner command to run automatically after login
-Note that if you use this feature.
+   <en>Enter the one-liner command to run automatically after login.
+If you use SU switch function runs SU switch later.
+If you use this feature with caution.
 This feature is not used if left blank.</en>
 </record>
 
@@ -286,9 +293,9 @@ Unit is milliseconds.</en>
 
 <record name="Form.AddProfile.Hint._suPasswordBox">
    <ja>スイッチするユーザのパスワードを入力します。
-パスワードは「SU パスワード」で指定されたプロンプト文字列を受信後に自動的にパスワードが入力されます。</ja>
+パスワードは「パスワードプロンプト」で指定された文字列を受信後に自動的に入力されます。</ja>
    <en>Enter the password for the user to switch.
-Passwords are automatically populated after receiving prompt string specified in item SU Password"".""</en>
+Passwords are automatically populated after receiving prompt string specified in item "Password Prompt".</en>
 </record>
 
 <record name="Form.AddProfile.Hint._suTypeRadio">
@@ -298,10 +305,10 @@ Passwords are automatically populated after receiving prompt string specified in
 
 <record name="Form.AddProfile.Hint._suUserNameBox">
    <ja>自動ログイン完了後にスイッチするユーザ名を入力します。
-この機能を使用する場合は注意してください。
+この機能を使用する場合は十分注意してください。
 未入力の場合はこの機能は使用されません。</ja>
    <en>Enter the user name to switch to auto login after.
-Note that if you use this feature.
+If you use this feature with caution.
 This feature is not used if left blank.</en>
 </record>
 
@@ -358,11 +365,6 @@ This feature is not used if left blank.</en>
 <record name="Form.ConnectProfile._autoLoginColumn">
   <ja>自動ログイン</ja>
   <en>Auto Login</en>
-</record>
-
-<record name="Form.ConnectProfile._charCodeColumn">
-  <ja>文字コード</ja>
-  <en>Char Code</en>
 </record>
 
 <record name="Form.ConnectProfile._checkAllOffButton">
@@ -428,11 +430,6 @@ This feature is not used if left blank.</en>
 <record name="Form.ConnectProfile._hostNameColumn">
   <ja>ホスト名</ja>
   <en>Host Name</en>
-</record>
-
-<record name="Form.ConnectProfile._newLineColumn">
-  <ja>改行コード</ja>
-  <en>New Line</en>
 </record>
 
 <record name="Form.ConnectProfile._openCSVFileDialog.Caption">

--- a/ConnectProfile/stringresource.xml
+++ b/ConnectProfile/stringresource.xml
@@ -1,0 +1,693 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<string-resource>
+
+<record name="Caption.AddProfile">
+  <ja>プロファイルの編集</ja>
+  <en>Edit Profile</en>
+</record>
+
+<record name="Caption.ConnectProfile">
+  <ja>Telnet/SSH接続プロファイル</ja>
+  <en>Telnet/SSH Connection Profile</en>
+</record>
+
+<record name="Command.ConnectProfile">
+  <ja>Telnet/SSH接続プロファイル</ja>
+  <en>Telnet/SSH Connection Profile</en>
+</record>
+
+<record name="Form.AddProfile._accountGroup">
+  <ja>アカウント</ja>
+  <en>Account</en>
+</record>
+
+<record name="Form.AddProfile._authTypeLabel">
+  <ja>認証方法</ja>
+  <en>Auth Type</en>
+</record>
+
+<record name="Form.AddProfile._autoLoginCheck">
+  <ja>使用する</ja>
+  <en>To Use</en>
+</record>
+
+<record name="Form.AddProfile._autoLoginGroup">
+  <ja>自動ログイン</ja>
+  <en>Auto Login</en>
+</record>
+
+<record name="Form.AddProfile._basicGroup">
+  <ja>基本情報</ja>
+  <en>Basic Information</en>
+</record>
+
+<record name="Form.AddProfile._charCodeLabel">
+  <ja>文字コード</ja>
+  <en>Char Code</en>
+</record>
+
+<record name="Form.AddProfile._commandSendIntLabel">
+  <ja>コマンド発行間隔 (ミリ秒)</ja>
+  <en>Command transmit interval (ms)</en>
+</record>
+
+<record name="Form.AddProfile._descriptionLabel">
+  <ja>備考</ja>
+  <en>Description</en>
+</record>
+
+<record name="Form.AddProfile._etcGroup">
+  <ja>その他</ja>
+  <en>Etc</en>
+</record>
+
+<record name="Form.AddProfile._execCommandLabel">
+  <ja>実行コマンド</ja>
+  <en>Run Command</en>
+</record>
+
+<record name="Form.AddProfile._hostNameLabel">
+  <ja>ホスト名</ja>
+  <en>Host Name</en>
+</record>
+
+<record name="Form.AddProfile._keyFileLabel">
+  <ja>秘密鍵ファイル</ja>
+  <en>Private Key File</en>
+</record>
+
+<record name="Form.AddProfile._loginPromptLabel">
+  <ja>ログインプロンプト</ja>
+  <en>Login Prompt</en>
+</record>
+
+<record name="Form.AddProfile._newLineTypeLabel">
+  <ja>改行コード</ja>
+  <en>New Line</en>
+</record>
+
+<record name="Form.AddProfile._openKeyFileButton">
+  <ja>...</ja>
+  <en>...</en>
+</record>
+
+<record name="Form.AddProfile._passwordLabel">
+  <ja>パスワード</ja>
+  <en>Password</en>
+</record>
+
+<record name="Form.AddProfile._passwordPromptLabel">
+  <ja>パスワードプロンプト</ja>
+  <en>Password Prompt</en>
+</record>
+
+<record name="Form.AddProfile._portLabel">
+  <ja>ポート</ja>
+  <en>Port</en>
+</record>
+
+<record name="Form.AddProfile._profileItemColorLabel">
+  <ja>プロファイル項目色</ja>
+  <en>Profile Item Color</en>
+</record>
+
+<record name="Form.AddProfile._promptRecvTimeoutLabel">
+  <ja>プロンプト受信タイムアウト (ミリ秒)</ja>
+  <en>Prompt Recv timeout (ms)</en>
+</record>
+
+<record name="Form.AddProfile._protocolLabel">
+  <ja>プロトコル</ja>
+  <en>Protocol</en>
+</record>
+
+<record name="Form.AddProfile._sshGroup">
+  <ja>SSHパラメータ</ja>
+  <en>SSH Parameter</en>
+</record>
+
+<record name="Form.AddProfile._suGroup">
+  <ja>SUスイッチ</ja>
+  <en>SU Switch</en>
+</record>
+
+<record name="Form.AddProfile._suPasswordLabel">
+  <ja>SUパスワード</ja>
+  <en>SU Password</en>
+</record>
+
+<record name="Form.AddProfile._suTypeLabel">
+  <ja>SUコマンド</ja>
+  <en>SU Command</en>
+</record>
+
+<record name="Form.AddProfile._suTypeRadio1">
+  <ja>su</ja>
+  <en>su</en>
+</record>
+
+<record name="Form.AddProfile._suTypeRadio2">
+  <ja>su -</ja>
+  <en>su -</en>
+</record>
+
+<record name="Form.AddProfile._suUserNameLabel">
+  <ja>SUユーザ名</ja>
+  <en>SU UserName</en>
+</record>
+
+<record name="Form.AddProfile._telnetNewLineCheck">
+  <ja>TelnetNewLine</ja>
+  <en>TelnetNewLine</en>
+</record>
+
+<record name="Form.AddProfile._terminalBGColorLabel">
+  <ja>ターミナル背景色</ja>
+  <en>Background Color</en>
+</record>
+
+<record name="Form.AddProfile._terminalFontColorLabel">
+  <ja>フォント色</ja>
+  <en>Font Color</en>
+</record>
+
+<record name="Form.AddProfile._terminalGroup">
+  <ja>ターミナル</ja>
+  <en>Terminal</en>
+</record>
+
+<record name="Form.AddProfile._terminalTypeLabel">
+  <ja>種類</ja>
+  <en>Terminal Type</en>
+</record>
+
+<record name="Form.AddProfile._userNameLabel">
+  <ja>ユーザ名</ja>
+  <en>User Name</en>
+</record>
+
+<record name="Form.AddProfile.Hint._authTypeBox">
+  <ja>SSH接続の認証方法を選択します。</ja>
+  <en>Select the SSH authentication method.</en>
+</record>
+
+<record name="Form.AddProfile.Hint._autoLoginCheck">
+   <ja>自動ログインを使用する場合はチェックをONにします。
+この機能を使用した場合は「実行コマンド」と「SUスイッチ」が使用できます。</ja>
+   <en>If you use the auto-login feature on the check.
+When using this feature can be used Run Command"" and ""SU switch"".""</en>
+</record>
+
+<record name="Form.AddProfile.Hint._charCodeBox">
+  <ja>文字コードを選択します。</ja>
+  <en>Select a character set.</en>
+</record>
+
+<record name="Form.AddProfile.Hint._commandSendIntBox">
+  <ja>コマンド発行の間隔を入力します。単位はミリ秒です。</ja>
+   <en>Enter the interval for issuing commands.
+Unit is milliseconds.</en>
+</record>
+
+<record name="Form.AddProfile.Hint._descriptionBox">
+  <ja>プロファイルの説明を入力します。</ja>
+  <en>Enter a description for the profile.</en>
+</record>
+
+<record name="Form.AddProfile.Hint._execCommandBox">
+   <ja>自動ログイン完了後に実行するコマンドをワンライナーで入力します。
+この機能を使用する場合は注意してください。
+未入力の場合はこの機能は使用されません。</ja>
+   <en>Enter the one-liner command to run automatically after login
+Note that if you use this feature.
+This feature is not used if left blank.</en>
+</record>
+
+<record name="Form.AddProfile.Hint._hostNameBox">
+  <ja>接続先のホスト名またはIPアドレスを入力します。</ja>
+  <en>Enter the destination host name or IP address.</en>
+</record>
+
+<record name="Form.AddProfile.Hint._keyFileBox">
+  <ja>秘密鍵ファイルを指定します。</ja>
+  <en>Specifies the private key file.</en>
+</record>
+
+<record name="Form.AddProfile.Hint._loginPromptBox">
+   <ja>ログインプロンプトを入力します。
+指定されたプロンプト文字列を受信後に自動的にユーザ名が入力されます。
+この項目では正規表現を使用することができます。</ja>
+   <en>Enter the login prompt.
+After receiving the prompt string given the username is entered automatically.
+This item can use regular expressions.</en>
+</record>
+
+<record name="Form.AddProfile.Hint._newLineTypeBox">
+  <ja>改行コードを選択します。</ja>
+  <en>Select the new line code.</en>
+</record>
+
+<record name="Form.AddProfile.Hint._passwordBox">
+  <ja>ログインパスワードを入力します。</ja>
+  <en>Enter the login password.</en>
+</record>
+
+<record name="Form.AddProfile.Hint._passwordPromptBox">
+   <ja>パスワードプロンプトを入力します。
+指定されたプロンプト文字列を受信後に自動的にパスワードが入力されます。
+この項目では正規表現を使用することができます。</ja>
+   <en>Enter the password prompt.
+After receiving the prompt string given the password is entered automatically.
+This item can use regular expressions.</en>
+</record>
+
+<record name="Form.AddProfile.Hint._portBox">
+   <ja>接続ポート番号を入力します。
+通常、Telnetは23番、SSHは22番です。</ja>
+  <en>Enter the connection port. Usually Telnet is 23, SSH is 22.</en>
+</record>
+
+<record name="Form.AddProfile.Hint._profileItemColorButton">
+  <ja>プロファイルの表示色を選択します。</ja>
+  <en>Select the profile item color.</en>
+</record>
+
+<record name="Form.AddProfile.Hint._promptRecvTimeoutBox">
+   <ja>自動ログイン機能を使用する際のプロンプトの受信タイムアウトを入力します。
+単位はミリ秒です。</ja>
+   <en>If you use the auto-login feature, enter the prompts the receive timeout.
+Unit is milliseconds.</en>
+</record>
+
+<record name="Form.AddProfile.Hint._protocolBox">
+  <ja>接続プロトコルを選択します。</ja>
+  <en>Select the connection protocol.</en>
+</record>
+
+<record name="Form.AddProfile.Hint._suPasswordBox">
+   <ja>スイッチするユーザのパスワードを入力します。
+パスワードは「SU パスワード」で指定されたプロンプト文字列を受信後に自動的にパスワードが入力されます。</ja>
+   <en>Enter the password for the user to switch.
+Passwords are automatically populated after receiving prompt string specified in item SU Password"".""</en>
+</record>
+
+<record name="Form.AddProfile.Hint._suTypeRadio">
+  <ja>スイッチコマンドを選択します。</ja>
+  <en>Select the switch command.</en>
+</record>
+
+<record name="Form.AddProfile.Hint._suUserNameBox">
+   <ja>自動ログイン完了後にスイッチするユーザ名を入力します。
+この機能を使用する場合は注意してください。
+未入力の場合はこの機能は使用されません。</ja>
+   <en>Enter the user name to switch to auto login after.
+Note that if you use this feature.
+This feature is not used if left blank.</en>
+</record>
+
+<record name="Form.AddProfile.Hint._telnetNewLineCheck">
+  <ja>TelnetNewLineを使用する場合はチェックをONにします。</ja>
+  <en>If you use the "Telnet NewLine" on the check.</en>
+</record>
+
+<record name="Form.AddProfile.Hint._terminalBGColorButton">
+  <ja>背景色を選択します。</ja>
+  <en>Select the background color.</en>
+</record>
+
+<record name="Form.AddProfile.Hint._terminalFontColorButton">
+  <ja>フォント色を選択します。</ja>
+  <en>Select a font color.</en>
+</record>
+
+<record name="Form.AddProfile.Hint._terminalTypeBox">
+  <ja>ターミナルの種類を選択します。</ja>
+  <en>Select the type of Terminal.</en>
+</record>
+
+<record name="Form.AddProfile.Hint._userNameBox">
+  <ja>ログインユーザ名を入力します。</ja>
+  <en>Enter the login name.</en>
+</record>
+
+<record name="Form.AddProfile.Hint.None">
+  <ja>ここに説明が表示されます。</ja>
+  <en>The description will be listed here.</en>
+</record>
+
+<record name="Form.Common._cancelButton">
+  <ja>キャンセル</ja>
+  <en>Cancel</en>
+</record>
+
+<record name="Form.Common._okButton">
+  <ja>OK</ja>
+  <en>OK</en>
+</record>
+
+<record name="Form.Common.WaterMark.Required">
+  <ja>必須</ja>
+  <en>Required</en>
+</record>
+
+<record name="Form.ConnectProfile._addProfileButton">
+  <ja>追加(&A)</ja>
+  <en>Add(&A)</en>
+</record>
+
+<record name="Form.ConnectProfile._autoLoginColumn">
+  <ja>自動ログイン</ja>
+  <en>Auto Login</en>
+</record>
+
+<record name="Form.ConnectProfile._charCodeColumn">
+  <ja>文字コード</ja>
+  <en>Char Code</en>
+</record>
+
+<record name="Form.ConnectProfile._checkAllOffButton">
+  <ja>チェック全解除(&U)</ja>
+  <en>Check All OFF(&U)</en>
+</record>
+
+<record name="Form.ConnectProfile._copyButton">
+  <ja>コピー(&C)</ja>
+  <en>Copy(&C)</en>
+</record>
+
+<record name="Form.ConnectProfile._csvExportButton">
+  <ja>CSV出力(&X)</ja>
+  <en>Export(&X)</en>
+</record>
+
+<record name="Form.ConnectProfile._csvImportButton">
+  <ja>CSV入力(&I)</ja>
+  <en>Import(&I)</en>
+</record>
+
+<record name="Form.ConnectProfile._delProfileButton">
+  <ja>削除(&D)</ja>
+  <en>Delete(&D)</en>
+</record>
+
+<record name="Form.ConnectProfile._descriptionColumn">
+  <ja>説明</ja>
+  <en>Description</en>
+</record>
+
+<record name="Form.ConnectProfile._displaySelectedOnlyCheck">
+  <ja>選択済みプロファイルのみ表示(&S)</ja>
+  <en>Display selected profile only(&S)</en>
+</record>
+
+<record name="Form.ConnectProfile._editProfileButton">
+  <ja>編集(&E)</ja>
+  <en>Edit(&E)</en>
+</record>
+
+<record name="Form.ConnectProfile._execCommandColumn">
+  <ja>実行コマンド</ja>
+  <en>Run Command</en>
+</record>
+
+<record name="Form.ConnectProfile._filterLabel">
+  <ja>フィルタ</ja>
+  <en>Filter</en>
+</record>
+
+<record name="Form.ConnectProfile._filterTextBox">
+  <ja>空白区切りでAND条件検索</ja>
+  <en>White space is 'AND condition'</en>
+</record>
+
+<record name="Form.ConnectProfile._hintLabel">
+  <ja>リスト上のダブルクリック操作 (左ボタン = 接続 / 中ボタン = 追加 / 右ボタン = 編集)</ja>
+  <en>Double-click action on the list (LeftButton = Connect / MiddleButton = Add / RightButton = Edit)</en>
+</record>
+
+<record name="Form.ConnectProfile._hostNameColumn">
+  <ja>ホスト名</ja>
+  <en>Host Name</en>
+</record>
+
+<record name="Form.ConnectProfile._newLineColumn">
+  <ja>改行コード</ja>
+  <en>New Line</en>
+</record>
+
+<record name="Form.ConnectProfile._openCSVFileDialog.Caption">
+  <ja>CSVファイルを選択</ja>
+  <en>Select CSV File</en>
+</record>
+
+<record name="Form.ConnectProfile._openCSVFileDialog.Filter">
+  <ja>CSVファイル (*.csv)|*.csv|すべてのファイル (*.*)|*.*</ja>
+  <en>CSV Files (*.csv)|*.csv|All Files (*.*)|*.*</en>
+</record>
+
+<record name="Form.ConnectProfile._portColumn">
+  <ja>ポート</ja>
+  <en>Port</en>
+</record>
+
+<record name="Form.ConnectProfile._profileCountLabel">
+  <ja>プロファイル数：{0}</ja>
+  <en>Profile Count : {0}</en>
+</record>
+
+<record name="Form.ConnectProfile._protocolColumn">
+  <ja>プロトコル</ja>
+  <en>Protocol</en>
+</record>
+
+<record name="Form.ConnectProfile._saveCSVFileDialog.Caption">
+  <ja>接続プロファイルをCSVに保存</ja>
+  <en>Save connection profiles to CSV</en>
+</record>
+
+<record name="Form.ConnectProfile._saveCSVFileDialog.Filter">
+  <ja>CSVファイル (*.csv)|*.csv|すべてのファイル (*.*)|*.*</ja>
+  <en>CSV Files (*.csv)|*.csv|All Files (*.*)|*.*</en>
+</record>
+
+<record name="Form.ConnectProfile._selectedProfileCountLabel">
+  <ja>選択数：{0}</ja>
+  <en>Selected : {0}</en>
+</record>
+
+<record name="Form.ConnectProfile._suSwitchColumn">
+  <ja>SUスイッチ</ja>
+  <en>SU Switch</en>
+</record>
+
+<record name="Form.ConnectProfile._terminalBGColorColumn">
+  <ja>背景色</ja>
+  <en>BG Color</en>
+</record>
+
+<record name="Form.ConnectProfile._userNameColumn">
+  <ja>ユーザ名</ja>
+  <en>User Name</en>
+</record>
+
+<record name="Form.ConnectProfile_profileListView.No">
+  <ja>しない</ja>
+  <en>No</en>
+</record>
+
+<record name="Form.ConnectProfile_profileListView.Yes">
+  <ja>する</ja>
+  <en>Yes</en>
+</record>
+
+<record name="Menu.ConnectProfile">
+  <ja>Telnet/SSH接続プロファイル</ja>
+  <en>Telnet/SSH Connection Profile</en>
+</record>
+
+<record name="Message.AddProfile.EmptyHostName">
+  <ja>ホスト名が入力されていません。</ja>
+  <en>Host name has not been entered.</en>
+</record>
+
+<record name="Message.AddProfile.EmptyKeyFile">
+  <ja>秘密鍵ファイルが指定されていません。</ja>
+  <en>The private key file has not been specified.</en>
+</record>
+
+<record name="Message.AddProfile.EmptyLoginPrompt">
+  <ja>ログインプロンプトが入力されていません。</ja>
+  <en>Login prompt has not been entered.</en>
+</record>
+
+<record name="Message.AddProfile.EmptyPassword">
+  <ja>パスワードが入力されていません。</ja>
+  <en>Password has not been entered.</en>
+</record>
+
+<record name="Message.AddProfile.EmptyPasswordPrompt">
+  <ja>パスワードプロンプトが入力されていません。</ja>
+  <en>Password prompt has not been entered.</en>
+</record>
+
+<record name="Message.AddProfile.EmptySUPassword">
+  <ja>スイッチするユーザのパスワードが入力されていません。</ja>
+  <en>Switch to the user's password is not entered.</en>
+</record>
+
+<record name="Message.AddProfile.EmptyUserName">
+  <ja>ユーザ名が入力されていません。</ja>
+  <en>User name has not been entered.</en>
+</record>
+
+<record name="Message.AddProfile.KeyFileNotExist">
+  <ja>指定した秘密鍵ファイルが存在しません。</ja>
+  <en>The specified private key file does not exist.</en>
+</record>
+
+<record name="Message.AddProfile.SUTypeNotSelect">
+  <ja>SUコマンドの種類が選択されていません。</ja>
+  <en>Kind of SU command has not been selected.</en>
+</record>
+
+<record name="Message.Connect.LoginPromptNotFound">
+  <ja>指定されたログインプロンプトが見つかりませんでした。</ja>
+  <en>The specified login prompt was not found.</en>
+</record>
+
+<record name="Message.Connect.PasswordPromptNotFound">
+  <ja>指定されたパスワードプロンプトが見つかりませんでした。</ja>
+  <en>The specified password prompt was not found.</en>
+</record>
+
+<record name="Message.ConnectProfile.ConnectCancel">
+  <ja>キャンセルしました。</ja>
+  <en>Has been cancelled.</en>
+</record>
+
+<record name="Message.ConnectProfile.ConnectConfirm">
+   <ja>{0}個のプロファイルが選択されています。接続しますか？
+{1}</ja>
+   <en>{0} profile is selected. Do you want to connect?
+{1}</en>
+</record>
+
+<record name="Message.ConnectProfile.CSVExportComplete">
+   <ja>CSVエクスポートが完了しました。文字コードはUTF8です。
+CSVヘッダー情報はインポート時に整合性確認を行っているため変更や削除は行わないでください。</ja>
+   <en>CSV export is complete. Encoding is UTF8.
+Because consistency checks during the Import CSV header information please do not modify or delete.</en>
+</record>
+
+<record name="Message.ConnectProfile.CSVExportDetetePasssword">
+  <ja>パスワードを削除して出力しますか？</ja>
+  <en>Removing password from the output?</en>
+</record>
+
+<record name="Message.ConnectProfile.CSVImportAppendProfileList">
+   <ja>現在のプロファイルリストに追加しますか？
+いいえを選択した場合は現在のプロファイルリストは全て削除されます。</ja>
+   <en>Do you add in the current profile it?
+If you choose 'NO' will remove all current profile list.</en>
+</record>
+
+<record name="Message.ConnectProfile.CSVImportCancel">
+  <ja>インポートをキャンセルしました。</ja>
+  <en>Import has been canceled.</en>
+</record>
+
+<record name="Message.ConnectProfile.CSVImportComplete">
+  <ja>CSVインポートが完了しました。</ja>
+  <en>CSV import is complete.</en>
+</record>
+
+<record name="Message.ConnectProfile.CSVImportConfirm">
+   <ja>インポートを実行しますか？
+インポート中にエラーが発生した場合は処理が中止され、現在のプロファイルリストが保持されます。</ja>
+   <en>Perform the import?
+If you encounter errors during the import process is aborted, retains the current profile.</en>
+</record>
+
+<record name="Message.ConnectProfile.CSVImportFailed">
+  <ja>CSVインポートに失敗しました。({0}行目)</ja>
+  <en>CSV import failed. (at line {0})</en>
+</record>
+
+<record name="Message.ConnectProfile.CSVImportInvalidAuthType">
+  <ja>SSH認証方法の指定が正しくありません。</ja>
+  <en>SSH AuthType specified is not valid.</en>
+</record>
+
+<record name="Message.ConnectProfile.CSVImportInvalidAutoLogin">
+  <ja>SSH認証方法の指定が正しくありません。</ja>
+  <en>AutoLogin specified is not valid.</en>
+</record>
+
+<record name="Message.ConnectProfile.CSVImportInvalidCharCode">
+  <ja>文字コードの指定が正しくありません。</ja>
+  <en>Character Code specified is not valid.</en>
+</record>
+
+<record name="Message.ConnectProfile.CSVImportInvalidCommandSendInterval">
+  <ja>コマンド発行間隔の指定が正しくありません。</ja>
+  <en>Command Transmit Interval specified is not valid.</en>
+</record>
+
+<record name="Message.ConnectProfile.CSVImportInvalidFieldCount">
+  <ja>CSVのフィールド数が正しくありません。 ({0}行目)</ja>
+  <en>Incorrect number of CSV fields. (at line {0})</en>
+</record>
+
+<record name="Message.ConnectProfile.CSVImportInvalidHeader">
+   <ja>CSVヘッダーの整合性チェックに失敗しました。({0}行目)
+CSVエクスポート時に出力されるヘッダーと同一にしてください。</ja>
+   <en>CSV header integrity check failed.  (at line {0})
+See identical to the header to print on CSV export.</en>
+</record>
+
+<record name="Message.ConnectProfile.CSVImportInvalidHostName">
+  <ja>ホスト名の指定が正しくありません。</ja>
+  <en>HostName specified is not valid.</en>
+</record>
+
+<record name="Message.ConnectProfile.CSVImportInvalidNewLine">
+  <ja>改行コードの指定が正しくありません。</ja>
+  <en>NewLine specified is not valid.</en>
+</record>
+
+<record name="Message.ConnectProfile.CSVImportInvalidPort">
+  <ja>ポートの指定が正しくありません。</ja>
+  <en>Port specified is not valid.</en>
+</record>
+
+<record name="Message.ConnectProfile.CSVImportInvalidPromptRecvTimeout">
+  <ja>プロンプト受信タイムアウトの指定が正しくありません。</ja>
+  <en>Prompt Receive Timeout specified is not valid.</en>
+</record>
+
+<record name="Message.ConnectProfile.CSVImportInvalidProtocol">
+  <ja>プロトコルの指定が正しくありません。</ja>
+  <en>Protocol specified is not valid.</en>
+</record>
+
+<record name="Message.ConnectProfile.CSVImportInvalidSUType">
+  <ja>SUコマンドの指定が正しくありません。</ja>
+  <en>SU Type specified is not valid.</en>
+</record>
+
+<record name="Message.ConnectProfile.CSVImportInvalidTelnetNewLine">
+  <ja>TelnetNewLineの指定が正しくありません。</ja>
+  <en>TelnetNewLine specified is not valid.</en>
+</record>
+
+<record name="Message.ConnectProfile.CSVImportInvalidTerminalType">
+  <ja>ターミナル種類の指定が正しくありません。</ja>
+  <en>TerminalType specified is not valid.</en>
+</record>
+
+<record name="Message.ConnectProfile.ProfileNotSelected">
+  <ja>プロファイルが選択されていません。</ja>
+  <en>Profile is not selected.</en>
+</record>
+
+</string-resource>

--- a/ConnectProfile/strings.resx
+++ b/ConnectProfile/strings.resx
@@ -1,0 +1,424 @@
+﻿<root>
+  <resheader name="ResMimeType">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="Version">
+    <value>1.0.0.0</value>
+  </resheader>
+  <resheader name="Reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=1.0.3102.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="Writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=1.0.3102.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Caption.AddProfile">
+    <value>Edit Profile</value>
+  </data>
+  <data name="Caption.ConnectProfile">
+    <value>Telnet/SSH Connection Profile</value>
+  </data>
+  <data name="Command.ConnectProfile">
+    <value>Telnet/SSH Connection Profile</value>
+  </data>
+  <data name="Form.AddProfile._authTypeLabel">
+    <value>Auth Type</value>
+  </data>
+  <data name="Form.AddProfile._autoLoginCheck">
+    <value>To Use</value>
+  </data>
+  <data name="Form.AddProfile._basicGroup">
+    <value>Basic Information</value>
+  </data>
+  <data name="Form.AddProfile._charCodeLabel">
+    <value>Char Code</value>
+  </data>
+  <data name="Form.AddProfile._descriptionLabel">
+    <value>Description</value>
+  </data>
+  <data name="Form.AddProfile._etcGroup">
+    <value>Etc</value>
+  </data>
+  <data name="Form.AddProfile._execCommandLabel">
+    <value>Run Command</value>
+  </data>
+  <data name="Form.AddProfile._hostNameLabel">
+    <value>Host Name</value>
+  </data>
+  <data name="Form.AddProfile._keyFileLabel">
+    <value>Private Key File</value>
+  </data>
+  <data name="Form.AddProfile._newLineTypeLabel">
+    <value>New Line</value>
+  </data>
+  <data name="Form.AddProfile._openKeyFileButton">
+    <value>...</value>
+  </data>
+  <data name="Form.AddProfile._passwordLabel">
+    <value>Password</value>
+  </data>
+  <data name="Form.AddProfile._passwordPromptLabel">
+    <value>Password Prompt</value>
+  </data>
+  <data name="Form.AddProfile._portLabel">
+    <value>Port</value>
+  </data>
+  <data name="Form.AddProfile._profileItemColorLabel">
+    <value>Profile Item Color</value>
+  </data>
+  <data name="Form.AddProfile._protocolLabel">
+    <value>Protocol</value>
+  </data>
+  <data name="Form.AddProfile._sshGroup">
+    <value>SSH Parameter</value>
+  </data>
+  <data name="Form.AddProfile._suGroup">
+    <value>SU Switch</value>
+  </data>
+  <data name="Form.AddProfile._suPasswordLabel">
+    <value>SU Password</value>
+  </data>
+  <data name="Form.AddProfile._suTypeLabel">
+    <value>SU Command</value>
+  </data>
+  <data name="Form.AddProfile._suTypeRadio1">
+    <value>su</value>
+  </data>
+  <data name="Form.AddProfile._suTypeRadio2">
+    <value>su -</value>
+  </data>
+  <data name="Form.AddProfile._suUserNameLabel">
+    <value>SU UserName</value>
+  </data>
+  <data name="Form.AddProfile._terminalBGColorLabel">
+    <value>Background Color</value>
+  </data>
+  <data name="Form.AddProfile._terminalFontColorLabel">
+    <value>Font Color</value>
+  </data>
+  <data name="Form.AddProfile._terminalGroup">
+    <value>Terminal</value>
+  </data>
+  <data name="Form.AddProfile._terminalTypeLabel">
+    <value>Terminal Type</value>
+  </data>
+  <data name="Form.AddProfile._userNameLabel">
+    <value>User Name</value>
+  </data>
+  <data name="Form.AddProfile._loginPromptLabel">
+    <value>Login Prompt</value>
+  </data>
+  <data name="Form.Common._cancelButton">
+    <value>Cancel</value>
+  </data>
+  <data name="Form.Common._okButton">
+    <value>OK</value>
+  </data>
+  <data name="Form.ConnectProfile._addProfileButton">
+    <value>Add(&amp;A)</value>
+  </data>
+  <data name="Form.ConnectProfile._autoLoginColumn">
+    <value>Auto Login</value>
+  </data>
+  <data name="Form.ConnectProfile._charCodeColumn">
+    <value>Char Code</value>
+  </data>
+  <data name="Form.ConnectProfile._checkAllOffButton">
+    <value>Check All OFF(&amp;U)</value>
+  </data>
+  <data name="Form.ConnectProfile._csvExportButton">
+    <value>Export(&amp;X)</value>
+  </data>
+  <data name="Form.ConnectProfile._csvImportButton">
+    <value>Import(&amp;I)</value>
+  </data>
+  <data name="Form.ConnectProfile._delProfileButton">
+    <value>Delete(&amp;D)</value>
+  </data>
+  <data name="Form.ConnectProfile._descriptionColumn">
+    <value>Description</value>
+  </data>
+  <data name="Form.ConnectProfile._editProfileButton">
+    <value>Edit(&amp;E)</value>
+  </data>
+  <data name="Form.ConnectProfile._execCommandColumn">
+    <value>Run Command</value>
+  </data>
+  <data name="Form.ConnectProfile._filterLabel">
+    <value>Filter</value>
+  </data>
+  <data name="Form.ConnectProfile._hostNameColumn">
+    <value>Host Name</value>
+  </data>
+  <data name="Form.ConnectProfile._newLineColumn">
+    <value>New Line</value>
+  </data>
+  <data name="Form.ConnectProfile._portColumn">
+    <value>Port</value>
+  </data>
+  <data name="Form.ConnectProfile._profileCountLabel">
+    <value>Profile Count : {0}</value>
+  </data>
+  <data name="Form.ConnectProfile._protocolColumn">
+    <value>Protocol</value>
+  </data>
+  <data name="Form.ConnectProfile._selectedProfileCountLabel">
+    <value>Selected : {0}</value>
+  </data>
+  <data name="Form.ConnectProfile._suSwitchColumn">
+    <value>SU Switch</value>
+  </data>
+  <data name="Form.ConnectProfile._terminalBGColorColumn">
+    <value>BG Color</value>
+  </data>
+  <data name="Form.ConnectProfile._userNameColumn">
+    <value>User Name</value>
+  </data>
+  <data name="Form.ConnectProfile_profileListView.No">
+    <value>No</value>
+  </data>
+  <data name="Form.ConnectProfile_profileListView.Yes">
+    <value>Yes</value>
+  </data>
+  <data name="Menu.ConnectProfile">
+    <value>Telnet/SSH Connection Profile</value>
+  </data>
+  <data name="Message.AddProfile.EmptyHostName">
+    <value>Host name has not been entered.</value>
+  </data>
+  <data name="Message.AddProfile.EmptyKeyFile">
+    <value>The private key file has not been specified.</value>
+  </data>
+  <data name="Message.AddProfile.EmptyPassword">
+    <value>Password has not been entered.</value>
+  </data>
+  <data name="Message.AddProfile.EmptyPasswordPrompt">
+    <value>Password prompt has not been entered.</value>
+  </data>
+  <data name="Message.AddProfile.EmptySUPassword">
+    <value>Switch to the user's password is not entered.</value>
+  </data>
+  <data name="Message.AddProfile.EmptyUserName">
+    <value>User name has not been entered.</value>
+  </data>
+  <data name="Message.AddProfile.EmptyLoginPrompt">
+    <value>Login prompt has not been entered.</value>
+  </data>
+  <data name="Message.AddProfile.KeyFileNotExist">
+    <value>The specified private key file does not exist.</value>
+  </data>
+  <data name="Message.AddProfile.SUTypeNotSelect">
+    <value>Kind of SU command has not been selected.</value>
+  </data>
+  <data name="Message.Connect.LoginPromptNotFound">
+    <value>The specified login prompt was not found.</value>
+  </data>
+  <data name="Message.Connect.PasswordPromptNotFound">
+    <value>The specified password prompt was not found.</value>
+  </data>
+  <data name="Form.AddProfile.Hint.None">
+    <value>The description will be listed here.</value>
+  </data>
+  <data name="Form.AddProfile.Hint._authTypeBox">
+    <value>Select the SSH authentication method.</value>
+  </data>
+  <data name="Form.AddProfile.Hint._autoLoginCheck">
+    <value>If you use the auto-login feature on the check.
+When using this feature can be used "Run Command" and "SU switch".</value>
+  </data>
+  <data name="Form.AddProfile.Hint._charCodeBox">
+    <value>Select a character set.</value>
+  </data>
+  <data name="Form.AddProfile.Hint._commandSendIntBox">
+    <value>Enter the interval for issuing commands.
+Unit is milliseconds.</value>
+  </data>
+  <data name="Form.AddProfile.Hint._descriptionBox">
+    <value>Enter a description for the profile.</value>
+  </data>
+  <data name="Form.AddProfile.Hint._execCommandBox">
+    <value>Enter the one-liner command to run automatically after login
+Note that if you use this feature.
+This feature is not used if left blank.</value>
+  </data>
+  <data name="Form.AddProfile.Hint._hostNameBox">
+    <value>Enter the destination host name or IP address.</value>
+  </data>
+  <data name="Form.AddProfile.Hint._keyFileBox">
+    <value>Specifies the private key file.</value>
+  </data>
+  <data name="Form.AddProfile.Hint._loginPromptBox">
+    <value>Enter the login prompt.
+After receiving the prompt string given the username is entered automatically.
+This item can use regular expressions.</value>
+  </data>
+  <data name="Form.AddProfile.Hint._newLineTypeBox">
+    <value>Select the new line code.</value>
+  </data>
+  <data name="Form.AddProfile.Hint._passwordBox">
+    <value>Enter the login password.</value>
+  </data>
+  <data name="Form.AddProfile.Hint._passwordPromptBox">
+    <value>Enter the password prompt.
+After receiving the prompt string given the password is entered automatically.
+This item can use regular expressions.</value>
+  </data>
+  <data name="Form.AddProfile.Hint._portBox">
+    <value>Enter the connection port. Usually Telnet is 23, SSH is 22.</value>
+  </data>
+  <data name="Form.AddProfile.Hint._profileItemColorButton">
+    <value>Select the profile item color.</value>
+  </data>
+  <data name="Form.AddProfile.Hint._promptRecvTimeoutBox">
+    <value>If you use the auto-login feature, enter the prompts the receive timeout.
+Unit is milliseconds.</value>
+  </data>
+  <data name="Form.AddProfile.Hint._protocolBox">
+    <value>Select the connection protocol.</value>
+  </data>
+  <data name="Form.AddProfile.Hint._suPasswordBox">
+    <value>Enter the password for the user to switch.
+Passwords are automatically populated after receiving prompt string specified in item "SU Password".</value>
+  </data>
+  <data name="Form.AddProfile.Hint._suTypeRadio">
+    <value>Select the switch command.</value>
+  </data>
+  <data name="Form.AddProfile.Hint._suUserNameBox">
+    <value>Enter the user name to switch to auto login after.
+Note that if you use this feature.
+This feature is not used if left blank.</value>
+  </data>
+  <data name="Form.AddProfile.Hint._telnetNewLineCheck">
+    <value>If you use the "Telnet NewLine" on the check.</value>
+  </data>
+  <data name="Form.AddProfile.Hint._terminalBGColorButton">
+    <value>Select the background color.</value>
+  </data>
+  <data name="Form.AddProfile.Hint._terminalFontColorButton">
+    <value>Select a font color.</value>
+  </data>
+  <data name="Form.AddProfile.Hint._terminalTypeBox">
+    <value>Select the type of Terminal.</value>
+  </data>
+  <data name="Form.AddProfile.Hint._userNameBox">
+    <value>Enter the login name.</value>
+  </data>
+  <data name="Form.AddProfile._accountGroup">
+    <value>Account</value>
+  </data>
+  <data name="Form.AddProfile._autoLoginGroup">
+    <value>Auto Login</value>
+  </data>
+  <data name="Form.AddProfile._commandSendIntLabel">
+    <value>Command transmit interval (ms)</value>
+  </data>
+  <data name="Form.AddProfile._promptRecvTimeoutLabel">
+    <value>Prompt Recv timeout (ms)</value>
+  </data>
+  <data name="Form.AddProfile._telnetNewLineCheck">
+    <value>TelnetNewLine</value>
+  </data>
+  <data name="Form.ConnectProfile._displaySelectedOnlyCheck">
+    <value>Display selected profile only(&amp;S)</value>
+  </data>
+  <data name="Form.ConnectProfile._filterTextBox">
+    <value>White space is 'AND condition'</value>
+  </data>
+  <data name="Message.ConnectProfile.ConnectConfirm">
+    <value>{0} profile is selected. Do you want to connect?
+{1}</value>
+  </data>
+  <data name="Message.ConnectProfile.ProfileNotSelected">
+    <value>Profile is not selected.</value>
+  </data>
+  <data name="Form.Common.WaterMark.Required">
+    <value>Required</value>
+  </data>
+  <data name="Form.ConnectProfile._openCSVFileDialog.Caption">
+    <value>Select CSV File</value>
+  </data>
+  <data name="Form.ConnectProfile._openCSVFileDialog.Filter">
+    <value>CSV Files (*.csv)|*.csv|All Files (*.*)|*.*</value>
+  </data>
+  <data name="Form.ConnectProfile._saveCSVFileDialog.Caption">
+    <value>Save connection profiles to CSV</value>
+  </data>
+  <data name="Form.ConnectProfile._saveCSVFileDialog.Filter">
+    <value>CSV Files (*.csv)|*.csv|All Files (*.*)|*.*</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVExportComplete">
+    <value>CSV export is complete. Encoding is UTF8.
+Because consistency checks during the Import CSV header information please do not modify or delete.</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVExportDetetePasssword">
+    <value>Removing password from the output?</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportComplete">
+    <value>CSV import is complete.</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportAppendProfileList">
+    <value>Do you add in the current profile it?
+If you choose 'NO' will remove all current profile list.</value>
+  </data>
+  <data name="Form.ConnectProfile._hintLabel">
+    <value>Double-click action on the list (LeftButton = Connect / MiddleButton = Add / RightButton = Edit)</value>
+  </data>
+  <data name="Form.ConnectProfile._copyButton">
+    <value>Copy(&amp;C)</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidHeader">
+    <value>CSV header integrity check failed.  (at line {0})
+See identical to the header to print on CSV export.</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportFailed">
+    <value>CSV import failed. (at line {0})</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidAuthType">
+    <value>SSH AuthType specified is not valid.</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidAutoLogin">
+    <value>AutoLogin specified is not valid.</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidCharCode">
+    <value>Character Code specified is not valid.</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidCommandSendInterval">
+    <value>Command Transmit Interval specified is not valid.</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidFieldCount">
+    <value>Incorrect number of CSV fields. (at line {0})</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidHostName">
+    <value>HostName specified is not valid.</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidNewLine">
+    <value>NewLine specified is not valid.</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidPort">
+    <value>Port specified is not valid.</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidPromptRecvTimeout">
+    <value>Prompt Receive Timeout specified is not valid.</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidProtocol">
+    <value>Protocol specified is not valid.</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidSUType">
+    <value>SU Type specified is not valid.</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidTelnetNewLine">
+    <value>TelnetNewLine specified is not valid.</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidTerminalType">
+    <value>TerminalType specified is not valid.</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportCancel">
+    <value>Import has been canceled.</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportConfirm">
+    <value>Perform the import?
+If you encounter errors during the import process is aborted, retains the current profile.</value>
+  </data>
+  <data name="Message.ConnectProfile.ConnectCancel">
+    <value>Has been cancelled.</value>
+  </data>
+</root>

--- a/ConnectProfile/strings.resx
+++ b/ConnectProfile/strings.resx
@@ -20,6 +20,9 @@
   <data name="Command.ConnectProfile">
     <value>Telnet/SSH Connection Profile</value>
   </data>
+  <data name="Caption.ConnectProfile.Connecting">
+    <value>Telnet/SSH Connection Profile (Connecting to {0})</value>
+  </data>
   <data name="Form.AddProfile._authTypeLabel">
     <value>Auth Type</value>
   </data>
@@ -119,11 +122,8 @@
   <data name="Form.ConnectProfile._autoLoginColumn">
     <value>Auto Login</value>
   </data>
-  <data name="Form.ConnectProfile._charCodeColumn">
-    <value>Char Code</value>
-  </data>
   <data name="Form.ConnectProfile._checkAllOffButton">
-    <value>Check All OFF(&amp;U)</value>
+    <value>Check All OFF(&amp;O)</value>
   </data>
   <data name="Form.ConnectProfile._csvExportButton">
     <value>Export(&amp;X)</value>
@@ -148,9 +148,6 @@
   </data>
   <data name="Form.ConnectProfile._hostNameColumn">
     <value>Host Name</value>
-  </data>
-  <data name="Form.ConnectProfile._newLineColumn">
-    <value>New Line</value>
   </data>
   <data name="Form.ConnectProfile._portColumn">
     <value>Port</value>
@@ -236,8 +233,9 @@ Unit is milliseconds.</value>
     <value>Enter a description for the profile.</value>
   </data>
   <data name="Form.AddProfile.Hint._execCommandBox">
-    <value>Enter the one-liner command to run automatically after login
-Note that if you use this feature.
+    <value>Enter the one-liner command to run automatically after login.
+If you use SU switch function runs SU switch later.
+If you use this feature with caution.
 This feature is not used if left blank.</value>
   </data>
   <data name="Form.AddProfile.Hint._hostNameBox">
@@ -277,14 +275,14 @@ Unit is milliseconds.</value>
   </data>
   <data name="Form.AddProfile.Hint._suPasswordBox">
     <value>Enter the password for the user to switch.
-Passwords are automatically populated after receiving prompt string specified in item "SU Password".</value>
+Passwords are automatically populated after receiving prompt string specified in item "Password Prompt".</value>
   </data>
   <data name="Form.AddProfile.Hint._suTypeRadio">
     <value>Select the switch command.</value>
   </data>
   <data name="Form.AddProfile.Hint._suUserNameBox">
     <value>Enter the user name to switch to auto login after.
-Note that if you use this feature.
+If you use this feature with caution.
 This feature is not used if left blank.</value>
   </data>
   <data name="Form.AddProfile.Hint._telnetNewLineCheck">

--- a/ConnectProfile/strings_ja.resx
+++ b/ConnectProfile/strings_ja.resx
@@ -20,6 +20,9 @@
   <data name="Command.ConnectProfile">
     <value>Telnet/SSH接続プロファイル</value>
   </data>
+  <data name="Caption.ConnectProfile.Connecting">
+    <value>Telnet/SSH接続プロファイル ({0} に接続中)</value>
+  </data>
   <data name="Form.AddProfile._authTypeLabel">
     <value>認証方法</value>
   </data>
@@ -33,7 +36,7 @@
     <value>文字コード</value>
   </data>
   <data name="Form.AddProfile._descriptionLabel">
-    <value>備考</value>
+    <value>説明</value>
   </data>
   <data name="Form.AddProfile._etcGroup">
     <value>その他</value>
@@ -119,11 +122,8 @@
   <data name="Form.ConnectProfile._autoLoginColumn">
     <value>自動ログイン</value>
   </data>
-  <data name="Form.ConnectProfile._charCodeColumn">
-    <value>文字コード</value>
-  </data>
   <data name="Form.ConnectProfile._checkAllOffButton">
-    <value>チェック全解除(&amp;U)</value>
+    <value>チェック全解除(&amp;O)</value>
   </data>
   <data name="Form.ConnectProfile._csvExportButton">
     <value>CSV出力(&amp;X)</value>
@@ -148,9 +148,6 @@
   </data>
   <data name="Form.ConnectProfile._hostNameColumn">
     <value>ホスト名</value>
-  </data>
-  <data name="Form.ConnectProfile._newLineColumn">
-    <value>改行コード</value>
   </data>
   <data name="Form.ConnectProfile._portColumn">
     <value>ポート</value>
@@ -229,14 +226,16 @@
     <value>文字コードを選択します。</value>
   </data>
   <data name="Form.AddProfile.Hint._commandSendIntBox">
-    <value>コマンド発行の間隔を入力します。単位はミリ秒です。</value>
+    <value>コマンド発行の間隔を入力します。
+単位はミリ秒です。</value>
   </data>
   <data name="Form.AddProfile.Hint._descriptionBox">
     <value>プロファイルの説明を入力します。</value>
   </data>
   <data name="Form.AddProfile.Hint._execCommandBox">
     <value>自動ログイン完了後に実行するコマンドをワンライナーで入力します。
-この機能を使用する場合は注意してください。
+SUスイッチ機能を使用する場合は、SUスイッチ後に実行されます。
+この機能を使用する場合は十分注意してください。
 未入力の場合はこの機能は使用されません。</value>
   </data>
   <data name="Form.AddProfile.Hint._hostNameBox">
@@ -277,14 +276,14 @@
   </data>
   <data name="Form.AddProfile.Hint._suPasswordBox">
     <value>スイッチするユーザのパスワードを入力します。
-パスワードは「SU パスワード」で指定されたプロンプト文字列を受信後に自動的にパスワードが入力されます。</value>
+パスワードは「パスワードプロンプト」で指定された文字列を受信後に自動的に入力されます。</value>
   </data>
   <data name="Form.AddProfile.Hint._suTypeRadio">
     <value>スイッチコマンドを選択します。</value>
   </data>
   <data name="Form.AddProfile.Hint._suUserNameBox">
     <value>自動ログイン完了後にスイッチするユーザ名を入力します。
-この機能を使用する場合は注意してください。
+この機能を使用する場合は十分注意してください。
 未入力の場合はこの機能は使用されません。</value>
   </data>
   <data name="Form.AddProfile.Hint._telnetNewLineCheck">

--- a/ConnectProfile/strings_ja.resx
+++ b/ConnectProfile/strings_ja.resx
@@ -1,0 +1,424 @@
+﻿<root>
+  <resheader name="ResMimeType">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="Version">
+    <value>1.0.0.0</value>
+  </resheader>
+  <resheader name="Reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=1.0.3102.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="Writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=1.0.3102.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Caption.AddProfile">
+    <value>プロファイルの編集</value>
+  </data>
+  <data name="Caption.ConnectProfile">
+    <value>Telnet/SSH接続プロファイル</value>
+  </data>
+  <data name="Command.ConnectProfile">
+    <value>Telnet/SSH接続プロファイル</value>
+  </data>
+  <data name="Form.AddProfile._authTypeLabel">
+    <value>認証方法</value>
+  </data>
+  <data name="Form.AddProfile._autoLoginCheck">
+    <value>使用する</value>
+  </data>
+  <data name="Form.AddProfile._basicGroup">
+    <value>基本情報</value>
+  </data>
+  <data name="Form.AddProfile._charCodeLabel">
+    <value>文字コード</value>
+  </data>
+  <data name="Form.AddProfile._descriptionLabel">
+    <value>備考</value>
+  </data>
+  <data name="Form.AddProfile._etcGroup">
+    <value>その他</value>
+  </data>
+  <data name="Form.AddProfile._execCommandLabel">
+    <value>実行コマンド</value>
+  </data>
+  <data name="Form.AddProfile._hostNameLabel">
+    <value>ホスト名</value>
+  </data>
+  <data name="Form.AddProfile._keyFileLabel">
+    <value>秘密鍵ファイル</value>
+  </data>
+  <data name="Form.AddProfile._newLineTypeLabel">
+    <value>改行コード</value>
+  </data>
+  <data name="Form.AddProfile._openKeyFileButton">
+    <value>...</value>
+  </data>
+  <data name="Form.AddProfile._passwordLabel">
+    <value>パスワード</value>
+  </data>
+  <data name="Form.AddProfile._passwordPromptLabel">
+    <value>パスワードプロンプト</value>
+  </data>
+  <data name="Form.AddProfile._portLabel">
+    <value>ポート</value>
+  </data>
+  <data name="Form.AddProfile._profileItemColorLabel">
+    <value>プロファイル項目色</value>
+  </data>
+  <data name="Form.AddProfile._protocolLabel">
+    <value>プロトコル</value>
+  </data>
+  <data name="Form.AddProfile._sshGroup">
+    <value>SSHパラメータ</value>
+  </data>
+  <data name="Form.AddProfile._suGroup">
+    <value>SUスイッチ</value>
+  </data>
+  <data name="Form.AddProfile._suPasswordLabel">
+    <value>SUパスワード</value>
+  </data>
+  <data name="Form.AddProfile._suTypeLabel">
+    <value>SUコマンド</value>
+  </data>
+  <data name="Form.AddProfile._suTypeRadio1">
+    <value>su</value>
+  </data>
+  <data name="Form.AddProfile._suTypeRadio2">
+    <value>su -</value>
+  </data>
+  <data name="Form.AddProfile._suUserNameLabel">
+    <value>SUユーザ名</value>
+  </data>
+  <data name="Form.AddProfile._terminalBGColorLabel">
+    <value>ターミナル背景色</value>
+  </data>
+  <data name="Form.AddProfile._terminalFontColorLabel">
+    <value>フォント色</value>
+  </data>
+  <data name="Form.AddProfile._terminalGroup">
+    <value>ターミナル</value>
+  </data>
+  <data name="Form.AddProfile._terminalTypeLabel">
+    <value>種類</value>
+  </data>
+  <data name="Form.AddProfile._userNameLabel">
+    <value>ユーザ名</value>
+  </data>
+  <data name="Form.AddProfile._loginPromptLabel">
+    <value>ログインプロンプト</value>
+  </data>
+  <data name="Form.Common._cancelButton">
+    <value>キャンセル</value>
+  </data>
+  <data name="Form.Common._okButton">
+    <value>OK</value>
+  </data>
+  <data name="Form.ConnectProfile._addProfileButton">
+    <value>追加(&amp;A)</value>
+  </data>
+  <data name="Form.ConnectProfile._autoLoginColumn">
+    <value>自動ログイン</value>
+  </data>
+  <data name="Form.ConnectProfile._charCodeColumn">
+    <value>文字コード</value>
+  </data>
+  <data name="Form.ConnectProfile._checkAllOffButton">
+    <value>チェック全解除(&amp;U)</value>
+  </data>
+  <data name="Form.ConnectProfile._csvExportButton">
+    <value>CSV出力(&amp;X)</value>
+  </data>
+  <data name="Form.ConnectProfile._csvImportButton">
+    <value>CSV入力(&amp;I)</value>
+  </data>
+  <data name="Form.ConnectProfile._delProfileButton">
+    <value>削除(&amp;D)</value>
+  </data>
+  <data name="Form.ConnectProfile._descriptionColumn">
+    <value>説明</value>
+  </data>
+  <data name="Form.ConnectProfile._editProfileButton">
+    <value>編集(&amp;E)</value>
+  </data>
+  <data name="Form.ConnectProfile._execCommandColumn">
+    <value>実行コマンド</value>
+  </data>
+  <data name="Form.ConnectProfile._filterLabel">
+    <value>フィルタ</value>
+  </data>
+  <data name="Form.ConnectProfile._hostNameColumn">
+    <value>ホスト名</value>
+  </data>
+  <data name="Form.ConnectProfile._newLineColumn">
+    <value>改行コード</value>
+  </data>
+  <data name="Form.ConnectProfile._portColumn">
+    <value>ポート</value>
+  </data>
+  <data name="Form.ConnectProfile._profileCountLabel">
+    <value>プロファイル数：{0}</value>
+  </data>
+  <data name="Form.ConnectProfile._protocolColumn">
+    <value>プロトコル</value>
+  </data>
+  <data name="Form.ConnectProfile._selectedProfileCountLabel">
+    <value>選択数：{0}</value>
+  </data>
+  <data name="Form.ConnectProfile._suSwitchColumn">
+    <value>SUスイッチ</value>
+  </data>
+  <data name="Form.ConnectProfile._terminalBGColorColumn">
+    <value>背景色</value>
+  </data>
+  <data name="Form.ConnectProfile._userNameColumn">
+    <value>ユーザ名</value>
+  </data>
+  <data name="Form.ConnectProfile_profileListView.No">
+    <value>しない</value>
+  </data>
+  <data name="Form.ConnectProfile_profileListView.Yes">
+    <value>する</value>
+  </data>
+  <data name="Menu.ConnectProfile">
+    <value>Telnet/SSH接続プロファイル</value>
+  </data>
+  <data name="Message.AddProfile.EmptyHostName">
+    <value>ホスト名が入力されていません。</value>
+  </data>
+  <data name="Message.AddProfile.EmptyKeyFile">
+    <value>秘密鍵ファイルが指定されていません。</value>
+  </data>
+  <data name="Message.AddProfile.EmptyPassword">
+    <value>パスワードが入力されていません。</value>
+  </data>
+  <data name="Message.AddProfile.EmptyPasswordPrompt">
+    <value>パスワードプロンプトが入力されていません。</value>
+  </data>
+  <data name="Message.AddProfile.EmptySUPassword">
+    <value>スイッチするユーザのパスワードが入力されていません。</value>
+  </data>
+  <data name="Message.AddProfile.EmptyUserName">
+    <value>ユーザ名が入力されていません。</value>
+  </data>
+  <data name="Message.AddProfile.EmptyLoginPrompt">
+    <value>ログインプロンプトが入力されていません。</value>
+  </data>
+  <data name="Message.AddProfile.KeyFileNotExist">
+    <value>指定した秘密鍵ファイルが存在しません。</value>
+  </data>
+  <data name="Message.AddProfile.SUTypeNotSelect">
+    <value>SUコマンドの種類が選択されていません。</value>
+  </data>
+  <data name="Message.Connect.LoginPromptNotFound">
+    <value>指定されたログインプロンプトが見つかりませんでした。</value>
+  </data>
+  <data name="Message.Connect.PasswordPromptNotFound">
+    <value>指定されたパスワードプロンプトが見つかりませんでした。</value>
+  </data>
+  <data name="Form.AddProfile.Hint.None">
+    <value>ここに説明が表示されます。</value>
+  </data>
+  <data name="Form.AddProfile.Hint._authTypeBox">
+    <value>SSH接続の認証方法を選択します。</value>
+  </data>
+  <data name="Form.AddProfile.Hint._autoLoginCheck">
+    <value>自動ログインを使用する場合はチェックをONにします。
+この機能を使用した場合は「実行コマンド」と「SUスイッチ」が使用できます。</value>
+  </data>
+  <data name="Form.AddProfile.Hint._charCodeBox">
+    <value>文字コードを選択します。</value>
+  </data>
+  <data name="Form.AddProfile.Hint._commandSendIntBox">
+    <value>コマンド発行の間隔を入力します。単位はミリ秒です。</value>
+  </data>
+  <data name="Form.AddProfile.Hint._descriptionBox">
+    <value>プロファイルの説明を入力します。</value>
+  </data>
+  <data name="Form.AddProfile.Hint._execCommandBox">
+    <value>自動ログイン完了後に実行するコマンドをワンライナーで入力します。
+この機能を使用する場合は注意してください。
+未入力の場合はこの機能は使用されません。</value>
+  </data>
+  <data name="Form.AddProfile.Hint._hostNameBox">
+    <value>接続先のホスト名またはIPアドレスを入力します。</value>
+  </data>
+  <data name="Form.AddProfile.Hint._keyFileBox">
+    <value>秘密鍵ファイルを指定します。</value>
+  </data>
+  <data name="Form.AddProfile.Hint._loginPromptBox">
+    <value>ログインプロンプトを入力します。
+指定されたプロンプト文字列を受信後に自動的にユーザ名が入力されます。
+この項目では正規表現を使用することができます。</value>
+  </data>
+  <data name="Form.AddProfile.Hint._newLineTypeBox">
+    <value>改行コードを選択します。</value>
+  </data>
+  <data name="Form.AddProfile.Hint._passwordBox">
+    <value>ログインパスワードを入力します。</value>
+  </data>
+  <data name="Form.AddProfile.Hint._passwordPromptBox">
+    <value>パスワードプロンプトを入力します。
+指定されたプロンプト文字列を受信後に自動的にパスワードが入力されます。
+この項目では正規表現を使用することができます。</value>
+  </data>
+  <data name="Form.AddProfile.Hint._portBox">
+    <value>接続ポート番号を入力します。
+通常、Telnetは23番、SSHは22番です。</value>
+  </data>
+  <data name="Form.AddProfile.Hint._profileItemColorButton">
+    <value>プロファイルの表示色を選択します。</value>
+  </data>
+  <data name="Form.AddProfile.Hint._promptRecvTimeoutBox">
+    <value>自動ログイン機能を使用する際のプロンプトの受信タイムアウトを入力します。
+単位はミリ秒です。</value>
+  </data>
+  <data name="Form.AddProfile.Hint._protocolBox">
+    <value>接続プロトコルを選択します。</value>
+  </data>
+  <data name="Form.AddProfile.Hint._suPasswordBox">
+    <value>スイッチするユーザのパスワードを入力します。
+パスワードは「SU パスワード」で指定されたプロンプト文字列を受信後に自動的にパスワードが入力されます。</value>
+  </data>
+  <data name="Form.AddProfile.Hint._suTypeRadio">
+    <value>スイッチコマンドを選択します。</value>
+  </data>
+  <data name="Form.AddProfile.Hint._suUserNameBox">
+    <value>自動ログイン完了後にスイッチするユーザ名を入力します。
+この機能を使用する場合は注意してください。
+未入力の場合はこの機能は使用されません。</value>
+  </data>
+  <data name="Form.AddProfile.Hint._telnetNewLineCheck">
+    <value>TelnetNewLineを使用する場合はチェックをONにします。</value>
+  </data>
+  <data name="Form.AddProfile.Hint._terminalBGColorButton">
+    <value>背景色を選択します。</value>
+  </data>
+  <data name="Form.AddProfile.Hint._terminalFontColorButton">
+    <value>フォント色を選択します。</value>
+  </data>
+  <data name="Form.AddProfile.Hint._terminalTypeBox">
+    <value>ターミナルの種類を選択します。</value>
+  </data>
+  <data name="Form.AddProfile.Hint._userNameBox">
+    <value>ログインユーザ名を入力します。</value>
+  </data>
+  <data name="Form.AddProfile._accountGroup">
+    <value>アカウント</value>
+  </data>
+  <data name="Form.AddProfile._autoLoginGroup">
+    <value>自動ログイン</value>
+  </data>
+  <data name="Form.AddProfile._commandSendIntLabel">
+    <value>コマンド発行間隔 (ミリ秒)</value>
+  </data>
+  <data name="Form.AddProfile._promptRecvTimeoutLabel">
+    <value>プロンプト受信タイムアウト (ミリ秒)</value>
+  </data>
+  <data name="Form.AddProfile._telnetNewLineCheck">
+    <value>TelnetNewLine</value>
+  </data>
+  <data name="Form.ConnectProfile._displaySelectedOnlyCheck">
+    <value>選択済みプロファイルのみ表示(&amp;S)</value>
+  </data>
+  <data name="Form.ConnectProfile._filterTextBox">
+    <value>空白区切りでAND条件検索</value>
+  </data>
+  <data name="Message.ConnectProfile.ConnectConfirm">
+    <value>{0}個のプロファイルが選択されています。接続しますか？
+{1}</value>
+  </data>
+  <data name="Message.ConnectProfile.ProfileNotSelected">
+    <value>プロファイルが選択されていません。</value>
+  </data>
+  <data name="Form.Common.WaterMark.Required">
+    <value>必須</value>
+  </data>
+  <data name="Form.ConnectProfile._openCSVFileDialog.Caption">
+    <value>CSVファイルを選択</value>
+  </data>
+  <data name="Form.ConnectProfile._openCSVFileDialog.Filter">
+    <value>CSVファイル (*.csv)|*.csv|すべてのファイル (*.*)|*.*</value>
+  </data>
+  <data name="Form.ConnectProfile._saveCSVFileDialog.Caption">
+    <value>接続プロファイルをCSVに保存</value>
+  </data>
+  <data name="Form.ConnectProfile._saveCSVFileDialog.Filter">
+    <value>CSVファイル (*.csv)|*.csv|すべてのファイル (*.*)|*.*</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVExportComplete">
+    <value>CSVエクスポートが完了しました。文字コードはUTF8です。
+CSVヘッダー情報はインポート時に整合性確認を行っているため変更や削除は行わないでください。</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVExportDetetePasssword">
+    <value>パスワードを削除して出力しますか？</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportComplete">
+    <value>CSVインポートが完了しました。</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportAppendProfileList">
+    <value>現在のプロファイルリストに追加しますか？
+いいえを選択した場合は現在のプロファイルリストは全て削除されます。</value>
+  </data>
+  <data name="Form.ConnectProfile._hintLabel">
+    <value>リスト上のダブルクリック操作 (左ボタン = 接続 / 中ボタン = 追加 / 右ボタン = 編集)</value>
+  </data>
+  <data name="Form.ConnectProfile._copyButton">
+    <value>コピー(&amp;C)</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidHeader">
+    <value>CSVヘッダーの整合性チェックに失敗しました。({0}行目)
+CSVエクスポート時に出力されるヘッダーと同一にしてください。</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportFailed">
+    <value>CSVインポートに失敗しました。({0}行目)</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidAuthType">
+    <value>SSH認証方法の指定が正しくありません。</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidAutoLogin">
+    <value>SSH認証方法の指定が正しくありません。</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidCharCode">
+    <value>文字コードの指定が正しくありません。</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidCommandSendInterval">
+    <value>コマンド発行間隔の指定が正しくありません。</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidFieldCount">
+    <value>CSVのフィールド数が正しくありません。 ({0}行目)</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidHostName">
+    <value>ホスト名の指定が正しくありません。</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidNewLine">
+    <value>改行コードの指定が正しくありません。</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidPort">
+    <value>ポートの指定が正しくありません。</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidPromptRecvTimeout">
+    <value>プロンプト受信タイムアウトの指定が正しくありません。</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidProtocol">
+    <value>プロトコルの指定が正しくありません。</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidSUType">
+    <value>SUコマンドの指定が正しくありません。</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidTelnetNewLine">
+    <value>TelnetNewLineの指定が正しくありません。</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportInvalidTerminalType">
+    <value>ターミナル種類の指定が正しくありません。</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportCancel">
+    <value>インポートをキャンセルしました。</value>
+  </data>
+  <data name="Message.ConnectProfile.CSVImportConfirm">
+    <value>インポートを実行しますか？
+インポート中にエラーが発生した場合は処理が中止され、現在のプロファイルリストが保持されます。</value>
+  </data>
+  <data name="Message.ConnectProfile.ConnectCancel">
+    <value>キャンセルしました。</value>
+  </data>
+</root>

--- a/Protocols/SimpleStringEncrypt.cs
+++ b/Protocols/SimpleStringEncrypt.cs
@@ -18,7 +18,7 @@ namespace Poderosa.Protocols {
     /// <summary>
     /// Simple string encyption with constant key.
     /// </summary>
-    internal class SimpleStringEncrypt {
+    public class SimpleStringEncrypt {
 
         // Method : DES
         //   Mode : CBC

--- a/UI/UI.csproj
+++ b/UI/UI.csproj
@@ -89,6 +89,7 @@
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="Util.cs" />
+    <Compile Include="WaterMarkTextBox.cs" />
     <Compile Include="Win32.cs" />
     <Compile Include="WinFormsUtil.cs" />
   </ItemGroup>

--- a/UI/WaterMarkTextBox.cs
+++ b/UI/WaterMarkTextBox.cs
@@ -1,0 +1,81 @@
+﻿using System.Drawing;
+using System.Windows.Forms;
+
+namespace Poderosa.UI {
+    /// <summary>
+    /// ウォーターマークテキスト付きTextBoxクラス
+    /// </summary>
+    public class WaterMarkTextBox : TextBox {
+        /// <summary>
+        /// ウォーターマークテキスト
+        /// </summary>
+        private string _waterMarkText = string.Empty;
+        /// <summary>
+        /// ウォーターマークテキストの色
+        /// </summary>
+        private Color _waterMarkColor = Color.Gray;
+        /// <summary>
+        /// フォーカス中もウォーターマークテキストを表示
+        /// </summary>
+        private bool _waterMarkAlsoFocus = false;
+
+        /// <summary>
+        /// Windowsメッセージを取得
+        /// </summary>
+        protected override void WndProc(ref Message m) {
+            bool isCallAlready = false;
+
+            if (m.Msg == 0x000F) { // WM_PAINT
+                base.WndProc(ref m);
+                isCallAlready = true;
+                DrawWaterMarkText();
+            } else if (m.Msg == 0x0008 && this.Multiline) { // WM_KILLFOCUS
+                DrawWaterMarkText();
+            }
+
+            if (false == isCallAlready) base.WndProc(ref m);
+        }
+
+        /// <summary>
+        /// ウォーターマークテキストを表示
+        /// </summary>
+        private void DrawWaterMarkText() {
+            // WaterMarkAlsoFocusがfalseの場合はフォーカス中にテキストを表示しない
+            if ((this.WaterMarkAlsoFocus == false) && (this.Focused == true)) return;
+
+            if ((string.IsNullOrEmpty(this.Text)) && (string.IsNullOrEmpty(this.WaterMarkText) == false) && (this.IsHandleCreated) && (this.Visible)) {
+                using (Graphics g = Graphics.FromHwnd(this.Handle)) {
+                    StringFormat sf = new StringFormat();
+                    float textHeight = g.MeasureString(this.WaterMarkText, this.Font, this.Width, sf).Height;
+                    float textY = ((float)this.Height - textHeight) / (float)2.0;
+                    RectangleF bounds = new RectangleF(0, textY, (float)this.Width, (float)this.Height - (textY * (float)2.0));
+                    g.DrawString(this.WaterMarkText, this.Font, new SolidBrush(this.WaterMarkColor), bounds, sf);
+                }
+            }
+        }
+
+        /// <summary>
+        /// ウォーターマークテキスト
+        /// </summary>
+        public string WaterMarkText {
+            get { return _waterMarkText; }
+            set { _waterMarkText = value; }
+        }
+
+        /// <summary>
+        /// ウォーターマークテキストの色
+        /// </summary>
+        public Color WaterMarkColor {
+            get { return _waterMarkColor; }
+            set { _waterMarkColor = value; }
+        }
+
+        /// <summary>
+        /// フォーカス中もウォーターマークテキストを表示
+        /// </summary>
+        public bool WaterMarkAlsoFocus {
+            get { return _waterMarkAlsoFocus; }
+            set { _waterMarkAlsoFocus = value; }
+        }
+    }
+}

--- a/UI/WaterMarkTextBox.cs
+++ b/UI/WaterMarkTextBox.cs
@@ -47,7 +47,7 @@ namespace Poderosa.UI {
                 using (Graphics g = Graphics.FromHwnd(this.Handle)) {
                     StringFormat sf = new StringFormat();
                     float textHeight = g.MeasureString(this.WaterMarkText, this.Font, this.Width, sf).Height;
-                    float textY = ((float)this.Height - textHeight) / (float)2.0;
+                    float textY = ((float)this.Height - textHeight) / (float)4.0;
                     RectangleF bounds = new RectangleF(0, textY, (float)this.Width, (float)this.Height - (textY * (float)2.0));
                     g.DrawString(this.WaterMarkText, this.Font, new SolidBrush(this.WaterMarkColor), bounds, sf);
                 }

--- a/build/cleanall.bat
+++ b/build/cleanall.bat
@@ -4,6 +4,7 @@ setlocal
 set PROJDIR=%~dp0..
 
 call :clean "%PROJDIR%\Benchmark"
+call :clean "%PROJDIR%\ConnectProfile"
 call :clean "%PROJDIR%\Core"
 call :clean "%PROJDIR%\Executable"
 call :clean "%PROJDIR%\Granados"

--- a/build/make-dist-bin.bat
+++ b/build/make-dist-bin.bat
@@ -22,7 +22,7 @@ copy "%PROJDIR%\Plugin%BINDIR%\Poderosa.Plugin.pdb" "%DIST%"
 copy "%PROJDIR%\Granados%BINDIR%\Granados.dll" "%DIST%"
 copy "%PROJDIR%\Granados%BINDIR%\Granados.pdb" "%DIST%"
 
-for %%P in (Core Macro PortForwardingCommand Protocols SerialPort TerminalEmulator TerminalSession UI Usability XZModem Pipe SFTP) do (
+for %%P in (Core Macro PortForwardingCommand Protocols SerialPort TerminalEmulator TerminalSession UI Usability XZModem Pipe SFTP ConnectProfile) do (
   MD "%DIST%\%%P"
   copy "%PROJDIR%\%%P%BINDIR%\Poderosa.%%P.dll" "%DIST%\%%P"
   copy "%PROJDIR%\%%P%BINDIR%\Poderosa.%%P.pdb" "%DIST%\%%P"

--- a/build/make-monolithic.bat
+++ b/build/make-monolithic.bat
@@ -16,7 +16,7 @@ set ASSYS=
 
 call :addfile "%PROJDIR%\Executable\bin\%CONFIG%\Poderosa.exe"
 
-for %%D in (Core Granados Macro Pipe Plugin PortForwardingCommand Protocols SerialPort SFTP TerminalEmulator TerminalSession UI Usability XZModem Benchmark) do (
+for %%D in (Core Granados Macro Pipe Plugin PortForwardingCommand Protocols SerialPort SFTP TerminalEmulator TerminalSession UI Usability XZModem Benchmark ConnectProfile) do (
   if exist "%PROJDIR%\%%D\bin\%CONFIG%\%%D.dll" (
     call :addfile "%PROJDIR%\%%D\bin\%CONFIG%\%%D.dll"
   ) else if exist "%PROJDIR%\%%D\bin\%CONFIG%\Poderosa.%%D.dll" (

--- a/poderosa.sln
+++ b/poderosa.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+# Visual Studio Express 2013 for Windows Desktop
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TerminalEmulator", "TerminalEmulator\TerminalEmulator.csproj", "{7F80731C-443A-4533-90D1-1643A5C1364E}"
 EndProject
@@ -36,6 +36,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pipe", "Pipe\Pipe.csproj", "{BA5ADFF2-747A-4090-B758-44C70FC1544F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SFTP", "SFTP\SFTP.csproj", "{A6D32222-4FA2-4197-9B48-36199FB49321}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConnectProfile", "ConnectProfile\ConnectProfile.csproj", "{A6A3F2DF-24B0-4471-88C2-1898167A976E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -181,6 +183,14 @@ Global
 		{A6D32222-4FA2-4197-9B48-36199FB49321}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A6D32222-4FA2-4197-9B48-36199FB49321}.UnitTest|Any CPU.ActiveCfg = Release|Any CPU
 		{A6D32222-4FA2-4197-9B48-36199FB49321}.UnitTest|Any CPU.Build.0 = Release|Any CPU
+		{A6A3F2DF-24B0-4471-88C2-1898167A976E}.Debug(UIDesign)|Any CPU.ActiveCfg = Debug|Any CPU
+		{A6A3F2DF-24B0-4471-88C2-1898167A976E}.Debug(UIDesign)|Any CPU.Build.0 = Debug|Any CPU
+		{A6A3F2DF-24B0-4471-88C2-1898167A976E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A6A3F2DF-24B0-4471-88C2-1898167A976E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A6A3F2DF-24B0-4471-88C2-1898167A976E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A6A3F2DF-24B0-4471-88C2-1898167A976E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A6A3F2DF-24B0-4471-88C2-1898167A976E}.UnitTest|Any CPU.ActiveCfg = Release|Any CPU
+		{A6A3F2DF-24B0-4471-88C2-1898167A976E}.UnitTest|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
お世話になっております。

接続プロファイルプラグイン(ConnectProfile)を作成致しましたのでPullReqさせて頂きました。

元々は、マクロを自作して使用していましたが、Poderosaプロジェクトの標準プラグインとして是非搭載して頂きたいと思っております。

簡易的ではありますが、下記に仕様を記載致します。
また、クラス概念があるプログラミングは不慣れのため、所々不備があるかと思いますがご了承頂きたく思います。

よろしくお願い致します。
※別件ですが前回のProfileConfirmについてはまだ手付かずですが近々作成予定です。

＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝
【変更内容】
●接続プロファイルプラグインを追加 (Add connection profile plugin.)
●UIプロジェクトに「WaterMarkTextBox」を追加 (Added "WaterMarkTextBox" to the UI project.)
●ProtocolsプロジェクトのSimpleStringEncryptを「internal」から「public」に変更 (Change SimpleStringEncrypt of Protocols project from "internal" to "public".)
＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝
【詳細】
●「ツール」メニューに「Telnet/SSH接続プロファイル」を追加 (キーバインド可能)
●各種項目を入力してそれらをプロファイルとして管理
●プロファイル操作は接続/追加/編集/削除/CSVエクスポート/CSVインポート
●プロファイルリストはフィルタリングを行うことが可能
●リストを複数チェックすることで複数プロファイルの連続接続が可能
●自動ログイン機能を搭載 (主にTelnetで活用)
●自動ログイン後にSUスイッチと指定したコマンドの実行が可能
●プロファイル毎にリストの項目色とターミナルの背景色/フォント色を設定可能 (開発環境/総合テスト環境/本番環境などで背景色を変更する用途を想定)
●パスワード暗号化/複合化用にSimpleStringEncryptを使用しているがクラスの種類を「internal」から「public」に変更 (ConnectProfileから参照不可だったため)
●透かし文字(ウォーターマーク)を設定できるTextBox継承の「WaterMarkTextBox」を追加
＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝
