### PR TITLE
w3mでマウスが使えない問題へのworkaround

### DIFF
--- a/TerminalEmulator/XTerm.cs
+++ b/TerminalEmulator/XTerm.cs
@@ -725,7 +725,6 @@ namespace Poderosa.Terminal {
                 if (_mouseTrackingState == MouseTrackingState.Off) {
                     _prevMouseRow = -1;
                     _prevMouseCol = -1;
-                    _mouseButton = MouseButtons.None;
                     SetDocumentCursor(Cursors.Arrow);
                 }
             }


### PR DESCRIPTION
現状、w3mでマウスが使えません。
原因はw3mがちょっとした事でmouse trackingのoff/onを行う為で、以下のような状況になっています。
 1. マウスボタンを押される
 2. Poderosa が button down 通知を送る
 3. w3m が button down 通知を受け取る
 4. w3m が一旦 mouse tracking を off にした後、on に戻す。
 5. mouse tracking が on に戻った時に、Poderosa が内部で管理しているマウスボタンの状態(_mouseButton)をクリアする
 6. マウスボタンが離される
 7. Poderosa の内部的にはマウスボタンが押されていない状態の為、button up 通知は送られない
 8. w3m は button up 通知が来ない為、マウスボタンクリックの処理を行わない

w3m が頻繁に mouse tracking の状態を切り替える事が問題だとも言えますが、Poderosa 側で mouse tracking が on 時にマウスボタンの状態をクリアしないようにする事で対応できるので、修正する事を提案します。
 
この修正によって考えられる他への影響ですが、マウスボタンを押している間に mouse tracking off → マウスボタンを離した後に mouse tracking on という状況で、_mouseButton と実際のマウスボタンの状態が食い違い最初のマウスボタンクリックが正しく処理されないというのが考えられます。
しかし、このような状況は滅多に発生しないと思われる事、および発生しても一度クリックをした後は正常に処理が行われるようになる事から、実際に発生している w3m での問題の対処を優先する方がいいと思います。