### PR TITLE
Add support for diffie-hellman-group{14,15,16}-sha256 key exchange

### DIFF
--- a/Granados/BigInteger.cs
+++ b/Granados/BigInteger.cs
@@ -146,7 +146,7 @@ namespace Granados {
         // maximum length of the BigInteger in uint (4 bytes)
         // change this to suit the required level of precision.
 
-        private const int maxLength = 130;
+        private const int maxLength = 260;
 
         // primes smaller than 2000 to test the generated prime number
         /// <summary>

--- a/Granados/SSHUtil.cs
+++ b/Granados/SSHUtil.cs
@@ -166,7 +166,10 @@ namespace Granados {
     public enum KexAlgorithm {
         None,
         DH_G1_SHA1,
-        DH_G14_SHA1
+        DH_G14_SHA1,
+        DH_G14_SHA256,
+        DH_G15_SHA256,
+        DH_G16_SHA256
     }
 }
 


### PR DESCRIPTION
まだInternet-Draftの段階ですが、diffie-hellman-group{14,15,16}-sha256 鍵交換への対応です。
c.f. https://datatracker.ietf.org/doc/draft-baushke-ssh-dh-group-sha2/

SLOTH攻撃 http://www.mitls.org/pages/attacks/SLOTH の事を考えると sha2 な鍵交換方式への
対応は有った方がいいと思います。

接続確認は OpenSSH 7.1p2 + dh-group{14,15,16}-sha256 パッチで行っています。
https://bugzilla.mindrot.org/show_bug.cgi?id=2515

Dropbear への接続がうまく行きませんが、4.3.15でも接続出来ないのでこの修正は無関係だと思われます。